### PR TITLE
added support for filtering out burst instances from recommendation

### DIFF
--- a/productinfo/productinfo.go
+++ b/productinfo/productinfo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -69,6 +70,12 @@ type Ec2Vm struct {
 	Cpus          float64 `json:"cpusPerVm"`
 	Mem           float64 `json:"memPerVm"`
 	Gpus          float64 `json:"gpusPerVm"`
+}
+
+// IsBurst returns true if the EC2 instance vCPU is burst type
+// the decision is made based on the instance type
+func (vm Ec2Vm) IsBurst() bool {
+	return strings.HasPrefix("T", strings.ToUpper(vm.Type))
 }
 
 // NewProductInfo creates a new ProductInfo instance

--- a/recommender/ec2.go
+++ b/recommender/ec2.go
@@ -78,6 +78,7 @@ func (e *Ec2VmRegistry) findVmsWithAttrValues(region string, zones []string, att
 				Cpus:          ec2vm.Cpus,
 				Mem:           ec2vm.Mem,
 				Gpus:          ec2vm.Gpus,
+				Burst:         ec2vm.IsBurst(),
 			}
 			vms = append(vms, vm)
 		}

--- a/recommender/engine_test.go
+++ b/recommender/engine_test.go
@@ -691,7 +691,7 @@ func TestEngine_burstFilter(t *testing.T) {
 		check  func(filterApplies bool)
 	}{
 		{
-			name:   "burst filter applies - burst vm, burst allowed",
+			name:   "burst filter applies - burst vm, burst allowed in req",
 			engine: Engine{},
 			req:    ClusterRecommendationReq{AllowBurst: &trueVal},
 			vm:     VirtualMachine{Burst: true},
@@ -702,23 +702,15 @@ func TestEngine_burstFilter(t *testing.T) {
 		{
 			name:   "burst filter applies - burst vm, burst not set in req",
 			engine: Engine{},
-			req:    ClusterRecommendationReq{},
-			vm:     VirtualMachine{Burst: true},
+			// BurstAllowed not specified
+			req: ClusterRecommendationReq{},
+			vm:  VirtualMachine{Burst: true},
 			check: func(filterApplies bool) {
 				assert.Equal(t, true, filterApplies, "vm should pass the  burst filter")
 			},
 		},
 		{
 			name:   "burst filter doesn't apply - burst vm, burst not allowed",
-			engine: Engine{},
-			req:    ClusterRecommendationReq{AllowBurst: &falseVal},
-			vm:     VirtualMachine{Burst: true},
-			check: func(filterApplies bool) {
-				assert.Equal(t, false, filterApplies, "vm should not pass the  burst filter")
-			},
-		},
-		{
-			name:   "burst filter doesn't apply - not burst vm, burst allowed",
 			engine: Engine{},
 			req:    ClusterRecommendationReq{AllowBurst: &falseVal},
 			vm:     VirtualMachine{Burst: true},

--- a/recommender/engine_test.go
+++ b/recommender/engine_test.go
@@ -652,9 +652,9 @@ func TestEngine_minMemRatioFilter(t *testing.T) {
 			name:   "minMemRatioFilter applies",
 			engine: Engine{},
 			// minRatio = SumMem/SumCpu = 2
-			req: ClusterRecommendationReq{SumMem: float64(8), SumCpu: 4,},
+			req: ClusterRecommendationReq{SumMem: float64(8), SumCpu: 4},
 			// ratio = Mem/Cpus = 4
-			vm:   VirtualMachine{Mem: float64(16), Cpus: 4,},
+			vm:   VirtualMachine{Mem: float64(16), Cpus: 4},
 			attr: Cpu,
 			check: func(filterApplies bool) {
 				assert.Equal(t, true, filterApplies, "vm should pass the  minMemRatioFilter")
@@ -664,7 +664,7 @@ func TestEngine_minMemRatioFilter(t *testing.T) {
 			name:   "minMemRatioFilter doesn't apply",
 			engine: Engine{},
 			// minRatio = SumMem/SumCpu = 2
-			req: ClusterRecommendationReq{SumMem: float64(8), SumCpu: 4,},
+			req: ClusterRecommendationReq{SumMem: float64(8), SumCpu: 4},
 			// ratio = Mem/Cpus = 0.5
 			vm:   VirtualMachine{Cpus: 4, Mem: float64(4)},
 			attr: Cpu,

--- a/recommender/engine_test.go
+++ b/recommender/engine_test.go
@@ -727,10 +727,11 @@ func TestEngine_burstFilter(t *testing.T) {
 			},
 		},
 		{
-			name:   "burst filter doesn't apply - not burst vm, burst not allowed",
+			name:   "burst filter applies - not burst vm, burst not allowed",
 			engine: Engine{},
 			req:    ClusterRecommendationReq{AllowBurst: &falseVal},
-			vm:     VirtualMachine{Burst: false},
+			// not a burst vm!
+			vm: VirtualMachine{Burst: false},
 			check: func(filterApplies bool) {
 				assert.Equal(t, true, filterApplies, "vm should pass the  burst filter")
 			},


### PR DESCRIPTION
* burst instance recommendation can be specified in the recommendation request (defaults to true)
* in case of ec2 instances the burst behavior is determined from the instance type (t prefix)
* the burst filter is passed by a vm if burst recommendation is not specified or alloved and the instance is a burst instance
* new and existing code covered with unit tests
* fixed encountered errors (there were a few) but the newly found one