### PR TITLE
provider limit and validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ swagger:
 build:
 	go build .
 
+build-all: check-fmt check-misspell lint vet swagger build
+
 check-fmt:
 	PKGS="${GOFILES_NOVENDOR}" GOFMT="gofmt" ./scripts/fmt-check.sh
 

--- a/api/validate.go
+++ b/api/validate.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"gopkg.in/go-playground/validator.v8"
+)
+
+// NewValidator returns Validate with custom validations configured
+func NewValidator(providers []string) *validator.Validate {
+	v := validator.New(&validator.Config{TagName: "validate"})
+	var providerString = fmt.Sprintf("^%s$", strings.Join(providers, "|"))
+	var passwordRegex = regexp.MustCompile(providerString)
+	v.RegisterValidation("provider_supported", func(v *validator.Validate, topStruct reflect.Value, currentStruct reflect.Value, field reflect.Value, fieldtype reflect.Type, fieldKind reflect.Kind, param string) bool {
+		return passwordRegex.MatchString(field.String())
+	})
+	return v
+}
+
+// ValidatePathParam is a gin middleware handler function that validates a named path parameter with specific Validate tags
+func ValidatePathParam(name string, validate *validator.Validate, tags ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		p := c.Param(name)
+		for _, tag := range tags {
+			err := validate.Field(p, tag)
+			if err != nil {
+				c.Abort()
+				c.JSON(http.StatusBadRequest, map[string]interface{}{
+					"code":    "bad_params",
+					"message": fmt.Sprintf("invalid %s parameter", name),
+					"params":  map[string]string{name: p},
+				})
+				return
+			}
+		}
+	}
+}

--- a/productinfo/productinfo.go
+++ b/productinfo/productinfo.go
@@ -143,14 +143,14 @@ func (pi *CachingProductInfo) Start(ctx context.Context) {
 			for _, attr := range attributes {
 				attrValues, err := pi.renewAttrValues(provider, attr)
 				if err != nil {
-					log.Errorf("couldn't renew attribute values in cache", err.Error())
+					log.Errorf("couldn't renew attribute values in cache: %s", err.Error())
 					return
 				}
 				for _, regionId := range infoer.GetRegions() {
 					for _, v := range attrValues {
 						_, err := pi.renewVmsWithAttr(provider, regionId, attr, v)
 						if err != nil {
-							log.Errorf("couldn't renew attribute values in cache", err.Error())
+							log.Errorf("couldn't renew attribute values in cache: %s", err.Error())
 						}
 					}
 				}
@@ -170,7 +170,7 @@ func (pi *CachingProductInfo) Start(ctx context.Context) {
 					defer wg.Done()
 					_, err := pi.renewShortLivedInfo(p, r)
 					if err != nil {
-						log.Errorf("couldn't renew short lived info in cache", err.Error())
+						log.Errorf("couldn't renew short lived info in cache: %s", err.Error())
 						return
 					}
 				}(provider, regionId)
@@ -284,7 +284,7 @@ func (pi *CachingProductInfo) renewShortLivedInfo(provider string, region string
 		return nil, err
 	}
 	for instType, p := range prices {
-		pi.vmAttrStore.Set(pi.getPriceKey(provider, region, instType), p, pi.renewalInterval)
+		pi.vmAttrStore.Set(pi.getPriceKey(provider, region, instType), p, 2*time.Minute)
 	}
 	return prices, nil
 }


### PR DESCRIPTION
We needed an option to limit providers from parameters, because when a user only has credentials for one cloud provider, we don't want the all the product info scrapers to run and report errors because of missing credentials.

The `-provider` option can be used to specify the providers to run. When selecting multiple providers, all of the following options are valid:
```
./telescopes -provider ec2 -provider gce
./telescopes -provider ec2,gce
./telescopes -provider "ec2 gce"
```

The default value of the provider flag contains all the currently supported providers.

The API responses with an error if a provider is set in the path and it's not configured, e.g.:
```
curl -sX POST -d '{"sumCpu": 7, [...], "zones":["eu-west-1a"]}' "localhost:9092/api/v1/recommender/myprovider/eu-west-1/cluster" | jq .
{
  "code": "bad_params",
  "message": "invalid provider parameter",
  "params": {
    "provider": "myprovider"
  }
}
```