### PR TITLE
#26 - Implement support for network performance filtering during recommendations

### DIFF
--- a/docs/openapi/recommender.yaml
+++ b/docs/openapi/recommender.yaml
@@ -87,6 +87,12 @@ paths:
           in: query
           schema:
             type: boolean
+        - x-go-name: NertworkPerf
+          description: NertworkPerf specifies the network performance category
+          name: networkPerf
+          in: query
+          schema:
+            type: string
       responses:
         '200':
           $ref: '#/components/responses/recommendationResp'
@@ -164,6 +170,10 @@ components:
           type: number
           format: double
           x-go-name: Mem
+        networkPerf:
+          description: NetworkPerf holds the network performance category
+          type: string
+          x-go-name: NetworkPerf
         onDemandPrice:
           description: Regular price of the instance type
           type: number

--- a/productinfo/ec2/networkmapping.go
+++ b/productinfo/ec2/networkmapping.go
@@ -2,8 +2,20 @@ package ec2
 
 import "github.com/banzaicloud/telescopes/productinfo"
 
+var (
+	ntwPerfMap = map[string][]string{
+		productinfo.NTW_HIGH:   {},
+		productinfo.NTW_MEDIUM: {},
+		productinfo.NTW_LOW:    {},
+	}
+)
+
 // Ec2NetworkMapper module object for handling amazon sopecific VM to Networking capabilities mapping
 type Ec2NetworkMapper struct {
+}
+
+func NewEc2NetworkMapper() Ec2NetworkMapper {
+	return Ec2NetworkMapper{}
 }
 
 func (nm *Ec2NetworkMapper) NetworkPerf(vm productinfo.VmInfo) (string, error) {

--- a/productinfo/ec2/networkmapping.go
+++ b/productinfo/ec2/networkmapping.go
@@ -1,0 +1,12 @@
+package ec2
+
+import "github.com/banzaicloud/telescopes/productinfo"
+
+// Ec2NetworkMapper module object for handling amazon sopecific VM to Networking capabilities mapping
+type Ec2NetworkMapper struct {
+}
+
+func (nm *Ec2NetworkMapper) NetworkPerf(vm productinfo.VmInfo) (string, error) {
+	// todo
+	return productinfo.NTW_HIGH, nil
+}

--- a/productinfo/ec2/networkmapping.go
+++ b/productinfo/ec2/networkmapping.go
@@ -33,7 +33,7 @@ func NewEc2NetworkMapper() Ec2NetworkMapper {
 	return Ec2NetworkMapper{}
 }
 
-func (nm *Ec2NetworkMapper) NetworkPerf(vm productinfo.VmInfo) (string, error) {
+func (nm *Ec2NetworkMapper) MapNetworkPerf(vm productinfo.VmInfo) (string, error) {
 	for perfCat, strVals := range ntwPerfMap {
 		if contains(strVals, vm.NtwPerf) {
 			return perfCat, nil

--- a/productinfo/ec2/networkmapping.go
+++ b/productinfo/ec2/networkmapping.go
@@ -1,12 +1,27 @@
 package ec2
 
-import "github.com/banzaicloud/telescopes/productinfo"
+import (
+	"fmt"
+	"github.com/banzaicloud/telescopes/productinfo"
+)
 
 var (
 	ntwPerfMap = map[string][]string{
-		productinfo.NTW_HIGH:   {},
-		productinfo.NTW_MEDIUM: {},
-		productinfo.NTW_LOW:    {},
+		// available categories
+		//"10 Gigabit"
+		//"20 Gigabit"
+		//"25 Gigabit"
+		//"High"
+		//"Low to Moderate"
+		//"Low"
+		//"Moderate"
+		//"NA"
+		//"Up to 10 Gigabit"
+		//"Very Low"
+
+		productinfo.NTW_LOW:    {"Very Low", "Low", "Low to Moderate"},
+		productinfo.NTW_MEDIUM: {"Moderate"},
+		productinfo.NTW_HIGH:   {"High", "Up to 10 Gigabit", "10 Gigabit", "20 Gigabit", "25 Gigabit"},
 	}
 )
 
@@ -19,6 +34,19 @@ func NewEc2NetworkMapper() Ec2NetworkMapper {
 }
 
 func (nm *Ec2NetworkMapper) NetworkPerf(vm productinfo.VmInfo) (string, error) {
-	// todo
-	return productinfo.NTW_HIGH, nil
+	for perfCat, strVals := range ntwPerfMap {
+		if contains(strVals, vm.NtwPerf) {
+			return perfCat, nil
+		}
+	}
+	return "", fmt.Errorf("could not determine network performance for: [%s]", vm.NtwPerf)
+}
+
+func contains(slice []string, val string) bool {
+	for _, v := range slice {
+		if v == val {
+			return true
+		}
+	}
+	return false
 }

--- a/productinfo/ec2/networkperfmap.go
+++ b/productinfo/ec2/networkperfmap.go
@@ -33,6 +33,7 @@ func NewEc2NetworkMapper() Ec2NetworkMapper {
 	return Ec2NetworkMapper{}
 }
 
+// MapNetworkPerf maps the network performance of the ec2 to the category supported ny telescope
 func (nm *Ec2NetworkMapper) MapNetworkPerf(vm productinfo.VmInfo) (string, error) {
 	for perfCat, strVals := range ntwPerfMap {
 		if contains(strVals, vm.NtwPerf) {

--- a/productinfo/ec2/networkperfmap.go
+++ b/productinfo/ec2/networkperfmap.go
@@ -29,7 +29,8 @@ var (
 type Ec2NetworkMapper struct {
 }
 
-func NewEc2NetworkMapper() Ec2NetworkMapper {
+// newEc2NetworkMapper initializes the network performance mapper struct
+func newEc2NetworkMapper() Ec2NetworkMapper {
 	return Ec2NetworkMapper{}
 }
 

--- a/productinfo/ec2/networkperfmap_test.go
+++ b/productinfo/ec2/networkperfmap_test.go
@@ -1,0 +1,48 @@
+package ec2
+
+import (
+	"github.com/banzaicloud/telescopes/productinfo"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// MapperSuit test suite for a network performance mapper implementation
+func MapperErrorSuit(t *testing.T, mapper productinfo.NetworkPerfMapper) {
+	// todo design meaningful suite(s) for testing mapper implementations
+	// todo eg: testing all the categories for a given impl, errors, etc ...
+}
+
+func TestEc2NetworkMapper_MapNetworkPerf(t *testing.T) {
+
+	mapper := Ec2NetworkMapper{}
+	tests := []struct {
+		name  string
+		vm    productinfo.VmInfo
+		check func(cat string, err error)
+	}{
+		{
+			name: "success - mapper maps to the lowest category",
+			vm: productinfo.VmInfo{
+				NtwPerf: "Very Low",
+			},
+			check: func(cat string, err error) {
+				assert.Equal(t, productinfo.NTW_LOW, cat, "not mapped to the right category")
+			},
+		},
+		{
+			name: "error - mapper doesn't map to a category",
+			vm: productinfo.VmInfo{
+				NtwPerf: "Error",
+			},
+			check: func(cat string, err error) {
+				assert.Equal(t, "", cat, "not mapped to the right category")
+				assert.Equal(t, "could not determine network performance for: [Error]", err.Error())
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.check(mapper.MapNetworkPerf(test.vm))
+		})
+	}
+}

--- a/productinfo/ec2/productinfo_ec2.go
+++ b/productinfo/ec2/productinfo_ec2.go
@@ -157,6 +157,11 @@ func (e *Ec2Infoer) GetProducts(regionId string, attrKey string, attrValue produ
 			log.Warn("could not retrieve on demand price")
 			continue
 		}
+		ntwPerf, err := pd.GetDataForKey("networkPerformance")
+		if err != nil {
+			log.Warn("could not parse network performance")
+			continue
+		}
 
 		onDemandPrice, _ := strconv.ParseFloat(odPriceStr, 32)
 		cpus, _ := strconv.ParseFloat(cpusStr, 32)
@@ -168,6 +173,7 @@ func (e *Ec2Infoer) GetProducts(regionId string, attrKey string, attrValue produ
 			Cpus:          cpus,
 			Mem:           mem,
 			Gpus:          gpus,
+			NtwPerf:       ntwPerf,
 		}
 		vms = append(vms, vm)
 	}
@@ -414,5 +420,6 @@ func (e *Ec2Infoer) GetCpuAttrName() string {
 }
 
 func (e *Ec2Infoer) GetNetworkMapper() (productinfo.NetworkMapper, error) {
-	return nil, errors.New("not yet implemented")
+	nm := NewEc2NetworkMapper()
+	return &nm, nil
 }

--- a/productinfo/ec2/productinfo_ec2.go
+++ b/productinfo/ec2/productinfo_ec2.go
@@ -412,3 +412,7 @@ func (e *Ec2Infoer) GetMemoryAttrName() string {
 func (e *Ec2Infoer) GetCpuAttrName() string {
 	return Cpu
 }
+
+func (e *Ec2Infoer) GetNetworkMapper() (productinfo.NetworkMapper, error) {
+	return nil, errors.New("not yet implemented")
+}

--- a/productinfo/ec2/productinfo_ec2.go
+++ b/productinfo/ec2/productinfo_ec2.go
@@ -419,7 +419,7 @@ func (e *Ec2Infoer) GetCpuAttrName() string {
 	return Cpu
 }
 
-func (e *Ec2Infoer) GetNetworkMapper() (productinfo.NetworkPerfMapper, error) {
+func (e *Ec2Infoer) GetNetworkPerformanceMapper() (productinfo.NetworkPerfMapper, error) {
 	nm := NewEc2NetworkMapper()
 	return &nm, nil
 }

--- a/productinfo/ec2/productinfo_ec2.go
+++ b/productinfo/ec2/productinfo_ec2.go
@@ -419,6 +419,7 @@ func (e *Ec2Infoer) GetCpuAttrName() string {
 	return Cpu
 }
 
+// GetNetworkPerformanceMapper gets the ec2 specific network performance mapper implementation
 func (e *Ec2Infoer) GetNetworkPerformanceMapper() (productinfo.NetworkPerfMapper, error) {
 	nm := NewEc2NetworkMapper()
 	return &nm, nil

--- a/productinfo/ec2/productinfo_ec2.go
+++ b/productinfo/ec2/productinfo_ec2.go
@@ -419,7 +419,7 @@ func (e *Ec2Infoer) GetCpuAttrName() string {
 	return Cpu
 }
 
-func (e *Ec2Infoer) GetNetworkMapper() (productinfo.NetworkMapper, error) {
+func (e *Ec2Infoer) GetNetworkMapper() (productinfo.NetworkPerfMapper, error) {
 	nm := NewEc2NetworkMapper()
 	return &nm, nil
 }

--- a/productinfo/ec2/productinfo_ec2.go
+++ b/productinfo/ec2/productinfo_ec2.go
@@ -421,6 +421,6 @@ func (e *Ec2Infoer) GetCpuAttrName() string {
 
 // GetNetworkPerformanceMapper gets the ec2 specific network performance mapper implementation
 func (e *Ec2Infoer) GetNetworkPerformanceMapper() (productinfo.NetworkPerfMapper, error) {
-	nm := NewEc2NetworkMapper()
+	nm := newEc2NetworkMapper()
 	return &nm, nil
 }

--- a/productinfo/ec2/productinfo_ec2_test.go
+++ b/productinfo/ec2/productinfo_ec2_test.go
@@ -91,9 +91,10 @@ func (dps *DummyPricingSource) GetProducts(input *pricing.GetProductsInput) (*pr
 				{
 					"product": map[string]interface{}{
 						"attributes": map[string]interface{}{
-							"instanceType": "db.t2.small",
-							Cpu:            "1",
-							Memory:         "2",
+							"instanceType":       "db.t2.small",
+							Cpu:                  "1",
+							Memory:               "2",
+							"networkPerformance": "Low to Moderate",
 						}},
 					"terms": map[string]interface{}{
 						"OnDemand": map[string]interface{}{
@@ -261,7 +262,7 @@ func TestEc2Infoer_GetProducts(t *testing.T) {
 			pricingServie: &DummyPricingSource{TcId: 4},
 			check: func(vm []productinfo.VmInfo, err error) {
 				assert.Nil(t, err, "the error should be nil")
-				assert.Equal(t, vm, []productinfo.VmInfo{productinfo.VmInfo{Type: "db.t2.small", OnDemandPrice: 5, SpotPrice: productinfo.PriceInfo(nil), Cpus: 1, Mem: 2, Gpus: 0}})
+				assert.Equal(t, []productinfo.VmInfo{{Type: "db.t2.small", OnDemandPrice: 5, SpotPrice: productinfo.PriceInfo(nil), Cpus: 1, Mem: 2, Gpus: 0, NtwPerf: "Low to Moderate"}}, vm)
 			},
 		},
 		{

--- a/productinfo/ec2/productinfo_ec2_test.go
+++ b/productinfo/ec2/productinfo_ec2_test.go
@@ -245,6 +245,8 @@ func TestEc2Infoer_GetRegions(t *testing.T) {
 	}
 }
 
+// todo better comment test cases, improve the setup
+// todo every test case should have its own fixture - it's hard to follow the individual cases
 func TestEc2Infoer_GetProducts(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/productinfo/gce/productinfo_gce.go
+++ b/productinfo/gce/productinfo_gce.go
@@ -56,7 +56,8 @@ func (g *GceInfoer) GetCpuAttrName() string {
 	return "cpu"
 }
 
-func (g *GceInfoer) GetNetworkMapper() (productinfo.NetworkPerfMapper, error) {
+// GetNetworkPerformanceMapper returns the network performance mappier implementation for this provider
+func (g *GceInfoer) GetNetworkPerformanceMapper() (productinfo.NetworkPerfMapper, error) {
 	//todo
 	return nil, errors.New("not yet implemented")
 }

--- a/productinfo/gce/productinfo_gce.go
+++ b/productinfo/gce/productinfo_gce.go
@@ -1,6 +1,7 @@
 package gce
 
 import (
+	"errors"
 	"github.com/banzaicloud/telescopes/productinfo"
 )
 
@@ -53,4 +54,9 @@ func (g *GceInfoer) GetMemoryAttrName() string {
 // GetCpuAttrName returns the provider representation of the cpu attribute
 func (g *GceInfoer) GetCpuAttrName() string {
 	return "cpu"
+}
+
+func (g *GceInfoer) GetNetworkMapper() (productinfo.NetworkMapper, error) {
+	//todo
+	return nil, errors.New("not yet implemented")
 }

--- a/productinfo/gce/productinfo_gce.go
+++ b/productinfo/gce/productinfo_gce.go
@@ -56,7 +56,7 @@ func (g *GceInfoer) GetCpuAttrName() string {
 	return "cpu"
 }
 
-func (g *GceInfoer) GetNetworkMapper() (productinfo.NetworkMapper, error) {
+func (g *GceInfoer) GetNetworkMapper() (productinfo.NetworkPerfMapper, error) {
 	//todo
 	return nil, errors.New("not yet implemented")
 }

--- a/productinfo/productinfo.go
+++ b/productinfo/productinfo.go
@@ -74,7 +74,7 @@ type ProductInfo interface {
 	// GetSpotPrice returns the zone averaged computed spot price for a given instance type in a given region
 	GetSpotPrice(provider string, region string, instanceType string, zones []string) (float64, error)
 
-	// GetNetworkPerfMapper retrieves the network performance mapper implementaiton
+	// GetNetworkPerfMapper retrieves the network performance mapper implementation
 	GetNetworkPerfMapper(provider string) (NetworkPerfMapper, error)
 }
 

--- a/productinfo/productinfo.go
+++ b/productinfo/productinfo.go
@@ -54,7 +54,7 @@ type ProductInfoer interface {
 	GetCpuAttrName() string
 
 	// GetNetworkMapper returns the provider specific network performance mapper
-	GetNetworkMapper() NetworkMapper
+	GetNetworkMapper() (NetworkMapper, error)
 }
 
 // ProductInfo is the main entry point for retrieving vm type characteristics and pricing information on different cloud providers
@@ -75,7 +75,7 @@ type ProductInfo interface {
 	GetSpotPrice(provider string, region string, instanceType string, zones []string) (float64, error)
 
 	// GetNetworkPerfMapper retrieves the network performance mapper implementaiton
-	GetNetworkPerfMapper(provider string) NetworkMapper
+	GetNetworkPerfMapper(provider string) (NetworkMapper, error)
 }
 
 // CachingProductInfo is the module struct, holds configuration and cache
@@ -382,5 +382,8 @@ func (pi *CachingProductInfo) GetZones(provider string, region string) ([]string
 
 // GetNetworkPerfMapper returns the provider specific network performance mapper
 func (pi *CachingProductInfo) GetNetworkPerfMapper(provider string) (NetworkMapper, error) {
-	return pi.productInfoers[provider].GetNetworkMapper(), nil
+	if infoer, ok := pi.productInfoers[provider]; ok {
+		return infoer.GetNetworkMapper() // this also can return with err!
+	}
+	return nil, fmt.Errorf("could not retrieve network perf mapper for provider: [%s]", provider)
 }

--- a/productinfo/productinfo.go
+++ b/productinfo/productinfo.go
@@ -53,8 +53,8 @@ type ProductInfoer interface {
 	// GetCpuAttrName returns the provider representation of the cpu attribute
 	GetCpuAttrName() string
 
-	// GetNetworkMapper returns the provider specific network performance mapper
-	GetNetworkMapper() (NetworkPerfMapper, error)
+	// GetNetworkPerformanceMapper returns the provider specific network performance mapper
+	GetNetworkPerformanceMapper() (NetworkPerfMapper, error)
 }
 
 // ProductInfo is the main entry point for retrieving vm type characteristics and pricing information on different cloud providers
@@ -384,7 +384,7 @@ func (pi *CachingProductInfo) GetZones(provider string, region string) ([]string
 // GetNetworkPerfMapper returns the provider specific network performance mapper
 func (pi *CachingProductInfo) GetNetworkPerfMapper(provider string) (NetworkPerfMapper, error) {
 	if infoer, ok := pi.productInfoers[provider]; ok {
-		return infoer.GetNetworkMapper() // this also can return with err!
+		return infoer.GetNetworkPerformanceMapper() // this also can return with err!
 	}
 	return nil, fmt.Errorf("could not retrieve network perf mapper for provider: [%s]", provider)
 }

--- a/productinfo/productinfo.go
+++ b/productinfo/productinfo.go
@@ -54,7 +54,7 @@ type ProductInfoer interface {
 	GetCpuAttrName() string
 
 	// GetNetworkMapper returns the provider specific network performance mapper
-	GetNetworkMapper() (NetworkMapper, error)
+	GetNetworkMapper() (NetworkPerfMapper, error)
 }
 
 // ProductInfo is the main entry point for retrieving vm type characteristics and pricing information on different cloud providers
@@ -75,7 +75,7 @@ type ProductInfo interface {
 	GetSpotPrice(provider string, region string, instanceType string, zones []string) (float64, error)
 
 	// GetNetworkPerfMapper retrieves the network performance mapper implementaiton
-	GetNetworkPerfMapper(provider string) (NetworkMapper, error)
+	GetNetworkPerfMapper(provider string) (NetworkPerfMapper, error)
 }
 
 // CachingProductInfo is the module struct, holds configuration and cache
@@ -124,7 +124,7 @@ func (vm VmInfo) IsBurst() bool {
 }
 
 //NetworkPerformance returns the network performance category for the vm
-func (vm VmInfo) NetworkPerformance(nm NetworkMapper) string {
+func (vm VmInfo) NetworkPerformance(nm NetworkPerfMapper) string {
 	nc, err := nm.NetworkPerf(vm)
 	if err != nil {
 		log.Warnf("could not get network performance for vm [%s], error: [%s]", vm.Type, err.Error())
@@ -382,7 +382,7 @@ func (pi *CachingProductInfo) GetZones(provider string, region string) ([]string
 }
 
 // GetNetworkPerfMapper returns the provider specific network performance mapper
-func (pi *CachingProductInfo) GetNetworkPerfMapper(provider string) (NetworkMapper, error) {
+func (pi *CachingProductInfo) GetNetworkPerfMapper(provider string) (NetworkPerfMapper, error) {
 	if infoer, ok := pi.productInfoers[provider]; ok {
 		return infoer.GetNetworkMapper() // this also can return with err!
 	}

--- a/productinfo/productinfo.go
+++ b/productinfo/productinfo.go
@@ -114,6 +114,7 @@ type VmInfo struct {
 	Cpus          float64   `json:"cpusPerVm"`
 	Mem           float64   `json:"memPerVm"`
 	Gpus          float64   `json:"gpusPerVm"`
+	NtwPerf       string    `json:"ntwPerf"`
 }
 
 // IsBurst returns true if the EC2 instance vCPU is burst type

--- a/productinfo/productinfo.go
+++ b/productinfo/productinfo.go
@@ -125,7 +125,7 @@ func (vm VmInfo) IsBurst() bool {
 
 //NetworkPerformance returns the network performance category for the vm
 func (vm VmInfo) NetworkPerformance(nm NetworkPerfMapper) string {
-	nc, err := nm.NetworkPerf(vm)
+	nc, err := nm.MapNetworkPerf(vm)
 	if err != nil {
 		log.Warnf("could not get network performance for vm [%s], error: [%s]", vm.Type, err.Error())
 	}

--- a/productinfo/types.go
+++ b/productinfo/types.go
@@ -1,6 +1,6 @@
 package productinfo
 
-const (
+var (
 	// network performance of vm-s
 	NTW_LOW    = "low"
 	NTW_MEDIUM = "medium"
@@ -9,6 +9,6 @@ const (
 
 // NetworkPerfMapper operations related  to mapping between virtual machines to network performance categories
 type NetworkPerfMapper interface {
-	// NetworkForMachine gets the network performance category for the given
-	NetworkPerf(vm VmInfo) (string, error)
+	// MapNetworkPerf gets the network performance category for the given
+	MapNetworkPerf(vm VmInfo) (string, error)
 }

--- a/productinfo/types.go
+++ b/productinfo/types.go
@@ -7,8 +7,8 @@ const (
 	NTW_HIGH   = "high"
 )
 
-// NetworkMapper operations related  to mapping between virtual machines to network performance categories
-type NetworkMapper interface {
+// NetworkPerfMapper operations related  to mapping between virtual machines to network performance categories
+type NetworkPerfMapper interface {
 	// NetworkForMachine gets the network performance category for the given
 	NetworkPerf(vm VmInfo) (string, error)
 }

--- a/productinfo/types.go
+++ b/productinfo/types.go
@@ -1,10 +1,14 @@
 package productinfo
 
 var (
-	// network performance of vm-s
-	NTW_LOW    = "low"
+	// telescope supported network performance of vm-s
+
+	// NTW_LOW the low network performance category
+	NTW_LOW = "low"
+	// NTW_MEDIUM the medium network performance category
 	NTW_MEDIUM = "medium"
-	NTW_HIGH   = "high"
+	// NTW_HIGH the high network performance category
+	NTW_HIGH = "high"
 )
 
 // NetworkPerfMapper operations related  to mapping between virtual machines to network performance categories

--- a/productinfo/types.go
+++ b/productinfo/types.go
@@ -1,0 +1,7 @@
+package productinfo
+
+// NetworkMapper operations related  to mapping between virtual machines to network performance categories
+type NetworkMapper interface {
+	// NetworkForMachine gets the network performance category for the given
+	NetworkPerf(vm VmInfo) (string, error)
+}

--- a/productinfo/types.go
+++ b/productinfo/types.go
@@ -1,5 +1,12 @@
 package productinfo
 
+const (
+	// network performance of vm-s
+	NTW_LOW    = "low"
+	NTW_MEDIUM = "medium"
+	NTW_HIGH   = "high"
+)
+
 // NetworkMapper operations related  to mapping between virtual machines to network performance categories
 type NetworkMapper interface {
 	// NetworkForMachine gets the network performance category for the given

--- a/recommender/engine.go
+++ b/recommender/engine.go
@@ -73,7 +73,7 @@ type ClusterRecommendationReq struct {
 	// Are burst instances allowed in recommendation
 	AllowBurst *bool `json:"allowBurst,omitempty"`
 	// NertworkPerf specifies the network performance category
-	NertworkPerf *string `json:"networkPerf,omitempty""`
+	NertworkPerf *string `json:"networkPerf,omitempty"`
 }
 
 // ClusterRecommendationResp encapsulates recommendation result data
@@ -372,7 +372,10 @@ func (e *Engine) findVmsWithAttrValues(provider string, region string, zones []s
 		zones = z
 	}
 
-	ntwMapper := e.productInfo.GetNetworkPerfMapper(provider)
+	ntwMapper, err := e.productInfo.GetNetworkPerfMapper(provider)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, v := range values {
 		vmInfos, err := e.productInfo.GetVmsWithAttrValue(provider, region, attr, v)

--- a/recommender/engine.go
+++ b/recommender/engine.go
@@ -72,6 +72,8 @@ type ClusterRecommendationReq struct {
 	SumGpu int `json:"sumGpu,omitempty"`
 	// Are burst instances allowed in recommendation
 	AllowBurst *bool `json:"allowBurst,omitempty"`
+	// NertworkPerf specifies the network performance category
+	NertworkPerf *string `json:"networkPerf,omitempty""`
 }
 
 // ClusterRecommendationResp encapsulates recommendation result data
@@ -111,6 +113,8 @@ type VirtualMachine struct {
 	Gpus float64 `json:"gpusPerVm"`
 	// Burst signals a burst type instance
 	Burst bool `json:"burst"`
+	// NetworkPerf holds the network performance category
+	NetworkPerf string `json:"networkPerf"`
 }
 
 func (v *VirtualMachine) getAttrValue(attr string) float64 {
@@ -368,6 +372,8 @@ func (e *Engine) findVmsWithAttrValues(provider string, region string, zones []s
 		zones = z
 	}
 
+	ntwMapper := e.productInfo.GetNetworkPerfMapper(provider)
+
 	for _, v := range values {
 		vmInfos, err := e.productInfo.GetVmsWithAttrValue(provider, region, attr, v)
 		if err != nil {
@@ -381,6 +387,7 @@ func (e *Engine) findVmsWithAttrValues(provider string, region string, zones []s
 				Mem:           vmInfo.Mem,
 				Gpus:          vmInfo.Gpus,
 				Burst:         vmInfo.IsBurst(),
+				NetworkPerf:   vmInfo.NetworkPerformance(ntwMapper),
 			}
 			spotPrice, err := e.productInfo.GetSpotPrice(provider, region, vmInfo.Type, zones)
 			if err != nil {

--- a/recommender/engine.go
+++ b/recommender/engine.go
@@ -155,6 +155,16 @@ func (e *Engine) minCpuRatioFilter(vm VirtualMachine, req ClusterRecommendationR
 	return true
 }
 
+func (e *Engine) ntwPerformanceFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
+	if req.NertworkPerf == nil { //there is no filter set
+		return true
+	}
+	if vm.NetworkPerf == *req.NertworkPerf { //the network performance category matches the vm
+		return true
+	}
+	return false
+}
+
 // filterSpots selects vm-s that potentially can be part of "spot" node pools
 func (e *Engine) filterSpots(vms []VirtualMachine) []VirtualMachine {
 	fvms := make([]VirtualMachine, 0)
@@ -448,9 +458,9 @@ func (e *Engine) RecommendAttrValues(provider string, attr string, req ClusterRe
 func (e *Engine) filtersForAttr(attr string) ([]vmFilter, error) {
 	switch attr {
 	case productinfo.Cpu:
-		return []vmFilter{e.minMemRatioFilter, e.burstFilter}, nil
+		return []vmFilter{e.ntwPerformanceFilter, e.minMemRatioFilter, e.burstFilter}, nil
 	case productinfo.Memory:
-		return []vmFilter{e.minCpuRatioFilter, e.burstFilter}, nil
+		return []vmFilter{e.ntwPerformanceFilter, e.minCpuRatioFilter, e.burstFilter}, nil
 	default:
 		return nil, fmt.Errorf("unsupported attribute: [%s]", attr)
 	}

--- a/recommender/engine_test.go
+++ b/recommender/engine_test.go
@@ -57,6 +57,14 @@ func TestNewEngine(t *testing.T) {
 	}
 }
 
+// dummy network mapper
+type dummyNetworkMapper struct {
+}
+
+func (dm dummyNetworkMapper) NetworkPerf(vm productinfo.VmInfo) (string, error) {
+	return productinfo.NTW_HIGH, nil
+}
+
 // utility VmRegistry for mocking purposes
 type dummyProductInfo struct {
 	// test case id to drive the behaviour
@@ -114,6 +122,11 @@ func (d *dummyProductInfo) GetSpotPrice(provider string, region string, instance
 
 	}
 	return 0, nil
+}
+
+func (d *dummyProductInfo) GetNetworkPerfMapper(provider string) (productinfo.NetworkMapper, error) {
+	nm := dummyNetworkMapper{}
+	return nm, nil
 }
 
 func TestEngine_RecommendAttrValues(t *testing.T) {

--- a/recommender/engine_test.go
+++ b/recommender/engine_test.go
@@ -124,7 +124,7 @@ func (d *dummyProductInfo) GetSpotPrice(provider string, region string, instance
 	return 0, nil
 }
 
-func (d *dummyProductInfo) GetNetworkPerfMapper(provider string) (productinfo.NetworkMapper, error) {
+func (d *dummyProductInfo) GetNetworkPerfMapper(provider string) (productinfo.NetworkPerfMapper, error) {
 	nm := dummyNetworkMapper{}
 	return nm, nil
 }

--- a/recommender/engine_test.go
+++ b/recommender/engine_test.go
@@ -553,7 +553,7 @@ func TestEngine_filtersForAttr(t *testing.T) {
 			pi:   &dummyProductInfo{},
 			attr: productinfo.Cpu,
 			check: func(vmfs []vmFilter, err error) {
-				assert.Equal(t, 2, len(vmfs), "invalid filter count")
+				assert.Equal(t, 3, len(vmfs), "invalid filter count")
 			},
 		},
 		{
@@ -561,7 +561,7 @@ func TestEngine_filtersForAttr(t *testing.T) {
 			pi:   &dummyProductInfo{},
 			attr: productinfo.Memory,
 			check: func(vmfs []vmFilter, err error) {
-				assert.Equal(t, 2, len(vmfs), "invalid filter count")
+				assert.Equal(t, 3, len(vmfs), "invalid filter count")
 			},
 		},
 	}


### PR DESCRIPTION
* implemented mechanism for translating provider specific network performance into "internal" categories (the solution abstracts the logic from the providers)
* implemented the initial mapping for ec2 (this can be easily modified by adding new internal categories or supporting all the categories from ec2)
* unit tests for the new components (more to come)
* updated swagger doc