### PR TITLE
#45 no spot instances available: recommendation fails 

### DIFF
--- a/recommender/engine.go
+++ b/recommender/engine.go
@@ -497,7 +497,6 @@ func (e *Engine) RecommendNodePools(attr string, vms []VirtualMachine, values []
 	// retain only the nodes that are available as spot instances
 	vms = e.filterSpots(vms)
 	if len(vms) == 0 {
-		// todo handle this case properly - recommend more on demand pools maybe
 		return nil, errors.New("no vm's suitable for spot pools")
 	}
 


### PR DESCRIPTION
* when no spot instances found, the recommendation fails (it can't satisfy conditions in the request)
* removed todo as the implementation was as expected
***please wait for the PR 26 to go in - this one is a no brainer**