### PR TITLE
section for dev-mode, disabling auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,10 +267,7 @@ See the answer above for more information.
 
 **19. Is this project production ready?**
 
-Not yet. To make this project production ready, we need at least the following things:
- - cover the code base with unit tests
- - authentication on the API
- - API validations
+Almost there. We are using this already internally and plan to GA it soon.
 
 **20. What is on the project roadmap for the near future?**
 

--- a/README.md
+++ b/README.md
@@ -229,14 +229,18 @@ Because spot prices can be different across availability zones, in this case the
 
 Yes, Google Cloud recommendations work as well, you should provide your GCE project id and the GCE api key as application flags to use it.
 
-**14. There's no bid pricing on Google Cloud, what will the recommender take into account there?**
+**14. Is there an Azure implementation?**
+
+Yes, Azure recommendations work as well, you should provide your Azure credentials as application flags to use it.
+
+**15. There's no bid pricing on Google Cloud, what will the recommender take into account there?**
 
 Even there's no bid pricing, Google Cloud can take your preemptible VMs away any time, and it still makes sense to diversify your node pools and minimize the risk
 of losing all your instances at once. Second, Google Cloud VM types are also complicated - there are standard, high-memory, high-cpu instances in different sizes,
 also special VM types, like shared-core and custom machine types, not to mention GPUs - so it makes sense to have a recommendation that takes these things into account as well.
 Managing a long-running cluster built from preemptible instances is also a hard task, we're working on that as well as part of the [Hollowtrees](https://github.com/banzaicloud/hollowtrees) project.
 
-**15. How is this project related to [Pipeline](https://github.com/banzaicloud/pipeline)?**
+**16. How is this project related to [Pipeline](https://github.com/banzaicloud/pipeline)?**
 
 Pipeline is able to start clusters with multiple node pools. This API is used in the Pipeline UI and CLI to recommend a cluster setup and to make it easy for
 a user to start a properly diversified spot instance based cluster. The recommender itself is not starting instances, it is the responsibility of Pipeline.
@@ -244,15 +248,14 @@ The recommendation can also be customized on the UI and CLI before sending the c
 
 Pipeline also provides the bearer token to be used when accessing the telescope API. (TBD)
 
-**16. Can the authentication be disabled from the telescopes API?**
+**17. Can the authentication be disabled from the telescopes API?**
 
 Authentication is enabled by default on the API. It *is* however possible to disable it by starting the application in development mode. (just start the app with the `--dev-mode` flag)
 
 Beware that (unrelated) behavior of the application may be affected in this mode (logging for example)
 It's not recommended to use the application in production with this flag!
 
-
-**17. How is this project related to [Hollowtrees](https://github.com/banzaicloud/hollowtrees)**
+**18. How is this project related to [Hollowtrees](https://github.com/banzaicloud/hollowtrees)**
 
 This project is only capable of recommending a static cluster layout that can be used to start a properly diversified spot cluster.
 But that is only one part of the whole picture: after the cluster is started it is still needed to be managed.
@@ -260,16 +263,16 @@ Spot instances can be taken away by the cloud provider or their price can change
 This maintenance work is done by Hollowtrees, that project is keeping the spot instance based cluster stable during its whole lifecycle.
 When some spot instances are taken away, Hollowtrees can ask the recommender to find substitutes based on the current layout.
 
-**18. What happens when the spot price of one of the instance types is rising after my cluster is running?**
+**19. What happens when the spot price of one of the instance types is rising after my cluster is running?**
 
 It is out of the scope of this project, but [Hollowtrees](https://github.com/banzaicloud/hollowtrees) will be able to handle that situtation.
 See the answer above for more information.
 
-**19. Is this project production ready?**
+**20. Is this project production ready?**
 
 Almost there. We are using this already internally and plan to GA it soon.
 
-**20. What is on the project roadmap for the near future?**
+**21. What is on the project roadmap for the near future?**
 
 The first priority is to stabilize the API and to make it production ready (see above).
 Other than that, these are the things we are planning to add soon:

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Because spot prices can be different across availability zones, in this case the
 
 **13. Is there a Google Cloud implementation?**
 
-Not yet, but we're planning to release it in the near future.
+Yes, Google Cloud recommendations work as well, you shoud provide your GCE project id and the GCE api key as application flags to use it.
 
 **14. There's no bid pricing on Google Cloud, what will the recommender take into account there?**
 
@@ -242,7 +242,17 @@ Pipeline is able to start clusters with multiple node pools. This API is used in
 a user to start a properly diversified spot instance based cluster. The recommender itself is not starting instances, it is the responsibility of Pipeline.
 The recommendation can also be customized on the UI and CLI before sending the cluster create request to Pipeline.
 
-**16. How is this project related to [Hollowtrees](https://github.com/banzaicloud/hollowtrees)**
+Pipeline also provides the bearer token to be used when accessing the telescope API. (TBD)
+
+**16. Can the authentication be disabled from the telescopes API?**
+
+Authentication is enabled by default on the API. It *is* however possible to disable it by starting the application in development mode. (just start the app with the `--dev-mode` flag)
+
+Beware that (unrelated) behavior of the application may be affected in this mode (logging for example)
+It's not recommended to use the application in production with this flag!
+
+
+**17. How is this project related to [Hollowtrees](https://github.com/banzaicloud/hollowtrees)**
 
 This project is only capable of recommending a static cluster layout that can be used to start a properly diversified spot cluster.
 But that is only one part of the whole picture: after the cluster is started it is still needed to be managed.
@@ -250,19 +260,19 @@ Spot instances can be taken away by the cloud provider or their price can change
 This maintenance work is done by Hollowtrees, that project is keeping the spot instance based cluster stable during its whole lifecycle.
 When some spot instances are taken away, Hollowtrees can ask the recommender to find substitutes based on the current layout.
 
-**17. What happens when the spot price of one of the instance types is rising after my cluster is running?**
+**18. What happens when the spot price of one of the instance types is rising after my cluster is running?**
 
 It is out of the scope of this project, but [Hollowtrees](https://github.com/banzaicloud/hollowtrees) will be able to handle that situtation.
 See the answer above for more information.
 
-**18. Is this project production ready?**
+**19. Is this project production ready?**
 
 Not yet. To make this project production ready, we need at least the following things:
  - cover the code base with unit tests
  - authentication on the API
  - API validations
 
-**19. What is on the project roadmap for the near future?**
+**20. What is on the project roadmap for the near future?**
 
 The first priority is to stabilize the API and to make it production ready (see above).
 Other than that, these are the things we are planning to add soon:

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Because spot prices can be different across availability zones, in this case the
 
 **13. Is there a Google Cloud implementation?**
 
-Yes, Google Cloud recommendations work as well, you shoud provide your GCE project id and the GCE api key as application flags to use it.
+Yes, Google Cloud recommendations work as well, you should provide your GCE project id and the GCE api key as application flags to use it.
 
 **14. There's no bid pricing on Google Cloud, what will the recommender take into account there?**
 


### PR DESCRIPTION
* GCE recommendation are supported
* small section for disabling the auth

(obtaining the bearer token from Pipeline still missing)

Related to: #54 