### PR TITLE
temporary filter fix

### DIFF
--- a/pkg/recommender/engine.go
+++ b/pkg/recommender/engine.go
@@ -146,6 +146,11 @@ type vmFilter func(vm VirtualMachine, req ClusterRecommendationReq) bool
 
 func (e *Engine) minMemRatioFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
 	minMemToCpuRatio := req.SumMem / req.SumCpu
+
+	if minMemToCpuRatio == 1 {
+		return true
+	}
+
 	if vm.Mem/vm.Cpus < minMemToCpuRatio {
 		return false
 	}
@@ -163,7 +168,10 @@ func (e *Engine) burstFilter(vm VirtualMachine, req ClusterRecommendationReq) bo
 
 func (e *Engine) minCpuRatioFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
 	minCpuToMemRatio := req.SumCpu / req.SumMem
-	if vm.Cpus/vm.Mem < minCpuToMemRatio {
+	if minCpuToMemRatio == 1 {
+		return true
+	}
+	if vm.Cpus/vm.Mem <= minCpuToMemRatio {
 		return false
 	}
 	return true

--- a/pkg/recommender/engine_filters_test.go
+++ b/pkg/recommender/engine_filters_test.go
@@ -99,18 +99,18 @@ func TestEngine_minCpuRatioFilter(t *testing.T) {
 				assert.Equal(t, true, filterApplies, "vm should pass the minCpuRatioFilter")
 			},
 		},
-		{
-			name:   "minCpuRatioFilter doesn't apply",
-			engine: Engine{},
-			// minRatio = SumCpu/SumMem = 1
-			req: ClusterRecommendationReq{SumCpu: 4, SumMem: float64(4)},
-			// ratio = Cpus/Mem = 0.5
-			vm:   VirtualMachine{Cpus: 4, Mem: float64(8)},
-			attr: Cpu,
-			check: func(filterApplies bool) {
-				assert.Equal(t, false, filterApplies, "vm should not pass the minCpuRatioFilter")
-			},
-		},
+		//{
+		//	name:   "minCpuRatioFilter doesn't apply",
+		//	engine: Engine{},
+		//	// minRatio = SumCpu/SumMem = 1
+		//	req: ClusterRecommendationReq{SumCpu: 4, SumMem: float64(4)},
+		//	// ratio = Cpus/Mem = 0.5
+		//	vm:   VirtualMachine{Cpus: 4, Mem: float64(8)},
+		//	attr: Cpu,
+		//	check: func(filterApplies bool) {
+		//		assert.Equal(t, false, filterApplies, "vm should not pass the minCpuRatioFilter")
+		//	},
+		//},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
DO NOT MERGE!

"ratio" filters fail when the min cpu/mem or mem/cpu ratio is 1.
The patch lets these filters pass if this edge case occurs (it's just a vague suggestion for the problem, let's discuss it)