### PR TITLE
Support for controlling instance type generations (AWS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/*
 conf/config.toml
 *.swp
 test.txt
+test-results

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,7 +29,7 @@
   version = "0.2.1"
 
 [[projects]]
-  branch = "productinfo"
+  branch = "master"
   name = "github.com/banzaicloud/productinfo"
   packages = [
     "pkg/productinfo-client/client",
@@ -39,7 +39,7 @@
     "pkg/productinfo-client/client/regions",
     "pkg/productinfo-client/models"
   ]
-  revision = "56754dd663d7d7153a367ac02cab2f4dd4cd18c2"
+  revision = "ca156d5bd2cb843e5c457fc61a8a432e340be203"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"

--- a/api/openapi-spec/recommender.json
+++ b/api/openapi-spec/recommender.json
@@ -37,20 +37,6 @@
         "operationId": "recommendClusterSetup",
         "parameters": [
           {
-            "type": "string",
-            "x-go-name": "Provider",
-            "name": "provider",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Region",
-            "name": "region",
-            "in": "path",
-            "required": true
-          },
-          {
             "type": "number",
             "format": "double",
             "x-go-name": "SumCpu",
@@ -125,7 +111,7 @@
           {
             "type": "string",
             "x-go-name": "NetworkPerf",
-            "description": "NertworkPerf specifies the network performance category",
+            "description": "NetworkPerf specifies the network performance category",
             "name": "networkPerf",
             "in": "query"
           },
@@ -148,6 +134,27 @@
             "description": "Includes is a whitelist - a slice with vm types to be contained in the recommendation",
             "name": "includes",
             "in": "query"
+          },
+          {
+            "type": "boolean",
+            "x-go-name": "AllowOlderGen",
+            "description": "AllowOlderGen allow older generations of virtual machines (applies for EC2 only)",
+            "name": "allowOlderGen",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Provider",
+            "name": "provider",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Region",
+            "name": "region",
+            "in": "path",
+            "required": true
           }
         ],
         "responses": {
@@ -181,7 +188,7 @@
           "x-go-name": "AttributeValues"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "ByAvgPricePerCpu": {
       "description": "ByAvgPricePerCpu type for custom sorting of a slice of vms",
@@ -204,7 +211,7 @@
       "type": "object",
       "properties": {
         "cpu": {
-          "description": "The summarised amount of cpu in the recommended cluster",
+          "description": "Number of recommended cpus",
           "type": "number",
           "format": "double",
           "x-go-name": "RecCpu"
@@ -215,11 +222,41 @@
           "format": "double",
           "x-go-name": "RecMem"
         },
-        "node": {
-          "description": "The summarised amount of node in the recommended cluster",
+        "nodes": {
+          "description": "Number of recommended nodes",
           "type": "integer",
           "format": "int64",
-          "x-go-name": "RecNode"
+          "x-go-name": "RecNodes"
+        },
+        "regularNodes": {
+          "description": "Number of regular instance type in the recommended cluster",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "RecRegularNodes"
+        },
+        "regularPrice": {
+          "description": "Amount of regular instance type prices in the recommended cluster",
+          "type": "number",
+          "format": "double",
+          "x-go-name": "RecRegularPrice"
+        },
+        "spotNodes": {
+          "description": "Number of spot instance type in the recommended cluster",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "RecSpotNodes"
+        },
+        "spotPrice": {
+          "description": "Amount of spot instance type prices in the recommended cluster",
+          "type": "number",
+          "format": "double",
+          "x-go-name": "RecSpotPrice"
+        },
+        "totalPrice": {
+          "description": "Total price in the recommended cluster",
+          "type": "number",
+          "format": "double",
+          "x-go-name": "RecTotalPrice"
         },
         "zone": {
           "description": "Availability zones in the recommendation",
@@ -240,6 +277,11 @@
           "description": "Are burst instances allowed in recommendation",
           "type": "boolean",
           "x-go-name": "AllowBurst"
+        },
+        "allowOlderGen": {
+          "description": "AllowOlderGen allow older generations of virtual machines (applies for EC2 only)",
+          "type": "boolean",
+          "x-go-name": "AllowOlderGen"
         },
         "excludes": {
           "description": "Excludes is a blacklist - a slice with vm types to be excluded from the recommendation",
@@ -270,7 +312,7 @@
           "x-go-name": "MinNodes"
         },
         "networkPerf": {
-          "description": "NertworkPerf specifies the network performance category",
+          "description": "NetworkPerf specifies the network performance category",
           "type": "string",
           "x-go-name": "NetworkPerf"
         },
@@ -344,7 +386,7 @@
           "x-go-name": "Region"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "GetProductDetailsParams": {
       "description": "GetProductDetailsParams GetProductDetailsParams is a placeholder for the get products route's path parameters",
@@ -361,7 +403,7 @@
           "x-go-name": "Region"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "GetRegionParams": {
       "description": "GetRegionParams GetRegionParams is a placeholder for the get region route's path parameters",
@@ -378,7 +420,7 @@
           "x-go-name": "Region"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "GetRegionResp": {
       "description": "GetRegionResp GetRegionResp holds the detailed description of a specific region of a cloud provider",
@@ -403,7 +445,7 @@
           "x-go-name": "Zones"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "GetRegionsParams": {
       "description": "GetRegionsParams GetRegionsParams is a placeholder for the get regions route's path parameters",
@@ -415,7 +457,7 @@
           "x-go-name": "Provider"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "GetRegionsResp": {
       "description": "GetRegionsResp GetRegionsResp holds the list of available regions of a cloud provider",
@@ -432,7 +474,7 @@
           "x-go-name": "Name"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "NodePool": {
       "description": "NodePool represents a set of instances with a specific vm type",
@@ -469,6 +511,11 @@
           "type": "number",
           "format": "double",
           "x-go-name": "Cpus"
+        },
+        "currentGen": {
+          "description": "CurrentGen signals whether the instance type generation is the current one. Only applies for amazon",
+          "type": "boolean",
+          "x-go-name": "CurrentGen"
         },
         "gpusPerVm": {
           "description": "gpus",
@@ -512,7 +559,7 @@
           "x-go-name": "Type"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "ProductDetailsResponse": {
       "description": "ProductDetailsResponse ProductDetailsResponse Api object to be mapped to product info response",
@@ -527,7 +574,7 @@
           "x-go-name": "Products"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "ProviderResponse": {
       "description": "ProviderResponse ProviderResponse is the response used for the supported providers",
@@ -535,7 +582,7 @@
       "items": {
         "type": "string"
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "RecommendationResponse": {
       "description": "ClusterRecommendationResp encapsulates recommendation result data",
@@ -584,7 +631,7 @@
           "x-go-name": "Name"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "RegionResp": {
       "description": "RegionResp RegionResp holds the list of available regions of a cloud provider",
@@ -601,7 +648,7 @@
           "x-go-name": "Name"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "RegionsResponse": {
       "description": "RegionsResponse RegionsResponse holds the list of available regions of a cloud provider",
@@ -609,7 +656,7 @@
       "items": {
         "$ref": "#/definitions/Region"
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "SpotPriceInfo": {
       "description": "SpotPriceInfo SpotPriceInfo represents different prices per availability zones",
@@ -618,7 +665,7 @@
         "type": "number",
         "format": "double"
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     },
     "VirtualMachine": {
       "description": "VirtualMachine describes an instance type",
@@ -640,6 +687,11 @@
           "type": "number",
           "format": "double",
           "x-go-name": "Cpus"
+        },
+        "currentGen": {
+          "description": "CurrentGen the vm is of current generation",
+          "type": "boolean",
+          "x-go-name": "CurrentGen"
         },
         "gpusPerVm": {
           "description": "Number of GPUs in the instance type",
@@ -693,7 +745,7 @@
           "x-go-name": "Zone"
         }
       },
-      "x-go-package": "github.com/banzaicloud/telescopes/pkg/productinfo-client/models"
+      "x-go-package": "github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models"
     }
   }
 }

--- a/api/openapi-spec/recommender.yaml
+++ b/api/openapi-spec/recommender.yaml
@@ -25,18 +25,6 @@ paths:
         specific region.
       operationId: recommendClusterSetup
       parameters:
-        - x-go-name: Provider
-          name: provider
-          in: path
-          required: true
-          schema:
-            type: string
-        - x-go-name: Region
-          name: region
-          in: path
-          required: true
-          schema:
-            type: string
         - x-go-name: SumCpu
           description: Total number of CPUs requested for the cluster
           name: sumCpu
@@ -100,7 +88,7 @@ paths:
           schema:
             type: boolean
         - x-go-name: NetworkPerf
-          description: NertworkPerf specifies the network performance category
+          description: NetworkPerf specifies the network performance category
           name: networkPerf
           in: query
           schema:
@@ -125,6 +113,26 @@ paths:
             type: array
             items:
               type: string
+        - x-go-name: AllowOlderGen
+          description: >-
+            AllowOlderGen allow older generations of virtual machines (applies
+            for EC2 only)
+          name: allowOlderGen
+          in: query
+          schema:
+            type: boolean
+        - x-go-name: Provider
+          name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+        - x-go-name: Region
+          name: region
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         '200':
           description: RecommendationResponse
@@ -151,7 +159,8 @@ components:
             type: number
             format: double
           x-go-name: AttributeValues
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     ByAvgPricePerCpu:
       description: ByAvgPricePerCpu type for custom sorting of a slice of vms
       type: array
@@ -169,7 +178,7 @@ components:
       type: object
       properties:
         cpu:
-          description: The summarised amount of cpu in the recommended cluster
+          description: Number of recommended cpus
           type: number
           format: double
           x-go-name: RecCpu
@@ -178,11 +187,36 @@ components:
           type: number
           format: double
           x-go-name: RecMem
-        node:
-          description: The summarised amount of node in the recommended cluster
+        nodes:
+          description: Number of recommended nodes
           type: integer
           format: int64
-          x-go-name: RecNode
+          x-go-name: RecNodes
+        regularNodes:
+          description: Number of regular instance type in the recommended cluster
+          type: integer
+          format: int64
+          x-go-name: RecRegularNodes
+        regularPrice:
+          description: Amount of regular instance type prices in the recommended cluster
+          type: number
+          format: double
+          x-go-name: RecRegularPrice
+        spotNodes:
+          description: Number of spot instance type in the recommended cluster
+          type: integer
+          format: int64
+          x-go-name: RecSpotNodes
+        spotPrice:
+          description: Amount of spot instance type prices in the recommended cluster
+          type: number
+          format: double
+          x-go-name: RecSpotPrice
+        totalPrice:
+          description: Total price in the recommended cluster
+          type: number
+          format: double
+          x-go-name: RecTotalPrice
         zone:
           description: Availability zones in the recommendation
           type: array
@@ -198,6 +232,12 @@ components:
           description: Are burst instances allowed in recommendation
           type: boolean
           x-go-name: AllowBurst
+        allowOlderGen:
+          description: >-
+            AllowOlderGen allow older generations of virtual machines (applies
+            for EC2 only)
+          type: boolean
+          x-go-name: AllowOlderGen
         excludes:
           description: >-
             Excludes is a blacklist - a slice with vm types to be excluded from
@@ -225,7 +265,7 @@ components:
           format: int64
           x-go-name: MinNodes
         networkPerf:
-          description: NertworkPerf specifies the network performance category
+          description: NetworkPerf specifies the network performance category
           type: string
           x-go-name: NetworkPerf
         onDemandPct:
@@ -287,7 +327,8 @@ components:
           description: 'in:path'
           type: string
           x-go-name: Region
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     GetProductDetailsParams:
       description: >-
         GetProductDetailsParams GetProductDetailsParams is a placeholder for the
@@ -302,7 +343,8 @@ components:
           description: 'in:path'
           type: string
           x-go-name: Region
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     GetRegionParams:
       description: >-
         GetRegionParams GetRegionParams is a placeholder for the get region
@@ -317,7 +359,8 @@ components:
           description: 'in:path'
           type: string
           x-go-name: Region
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     GetRegionResp:
       description: >-
         GetRegionResp GetRegionResp holds the detailed description of a specific
@@ -338,7 +381,8 @@ components:
           items:
             type: string
           x-go-name: Zones
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     GetRegionsParams:
       description: >-
         GetRegionsParams GetRegionsParams is a placeholder for the get regions
@@ -349,7 +393,8 @@ components:
           description: 'in:path'
           type: string
           x-go-name: Provider
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     GetRegionsResp:
       description: >-
         GetRegionsResp GetRegionsResp holds the list of available regions of a
@@ -364,7 +409,8 @@ components:
           description: name
           type: string
           x-go-name: Name
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     NodePool:
       description: NodePool represents a set of instances with a specific vm type
       type: object
@@ -398,6 +444,12 @@ components:
           type: number
           format: double
           x-go-name: Cpus
+        currentGen:
+          description: >-
+            CurrentGen signals whether the instance type generation is the
+            current one. Only applies for amazon
+          type: boolean
+          x-go-name: CurrentGen
         gpusPerVm:
           description: gpus
           type: number
@@ -431,7 +483,8 @@ components:
           description: type
           type: string
           x-go-name: Type
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     ProductDetailsResponse:
       description: >-
         ProductDetailsResponse ProductDetailsResponse Api object to be mapped to
@@ -446,7 +499,8 @@ components:
           items:
             $ref: '#/components/schemas/ProductDetails'
           x-go-name: Products
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     ProviderResponse:
       description: >-
         ProviderResponse ProviderResponse is the response used for the supported
@@ -454,7 +508,8 @@ components:
       type: array
       items:
         type: string
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     RecommendationResponse:
       description: ClusterRecommendationResp encapsulates recommendation result data
       type: object
@@ -493,7 +548,8 @@ components:
           description: name
           type: string
           x-go-name: Name
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     RegionResp:
       description: >-
         RegionResp RegionResp holds the list of available regions of a cloud
@@ -508,7 +564,8 @@ components:
           description: name
           type: string
           x-go-name: Name
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     RegionsResponse:
       description: >-
         RegionsResponse RegionsResponse holds the list of available regions of a
@@ -516,7 +573,8 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Region'
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     SpotPriceInfo:
       description: >-
         SpotPriceInfo SpotPriceInfo represents different prices per availability
@@ -525,7 +583,8 @@ components:
       additionalProperties:
         type: number
         format: double
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
     VirtualMachine:
       description: VirtualMachine describes an instance type
       type: object
@@ -546,6 +605,10 @@ components:
           type: number
           format: double
           x-go-name: Cpus
+        currentGen:
+          description: CurrentGen the vm is of current generation
+          type: boolean
+          x-go-name: CurrentGen
         gpusPerVm:
           description: Number of GPUs in the instance type
           type: number
@@ -587,5 +650,6 @@ components:
           description: zone
           type: string
           x-go-name: Zone
-      x-go-package: github.com/banzaicloud/telescopes/pkg/productinfo-client/models
+      x-go-package: >-
+        github.com/banzaicloud/telescopes/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models
 

--- a/pkg/recommender/engine.go
+++ b/pkg/recommender/engine.go
@@ -75,7 +75,7 @@ type ClusterRecommendationReq struct {
 	// Includes is a whitelist - a slice with vm types to be contained in the recommendation
 	Includes []string `json:"includes,omitempty"`
 	// AllowOlderGen allow older generations of virtual machines (applies for EC2 only)
-	AllowOlderGen *bool
+	AllowOlderGen *bool `json:"allowOlderGen,omitempty"`
 }
 
 // ClusterRecommendationResp encapsulates recommendation result data

--- a/pkg/recommender/engine.go
+++ b/pkg/recommender/engine.go
@@ -74,6 +74,8 @@ type ClusterRecommendationReq struct {
 	Excludes []string `json:"excludes,omitempty"`
 	// Includes is a whitelist - a slice with vm types to be contained in the recommendation
 	Includes []string `json:"includes,omitempty"`
+	// AllowOlderGen allow older generations of virtual machines (applies for EC2 only)
+	AllowOlderGen *bool
 }
 
 // ClusterRecommendationResp encapsulates recommendation result data
@@ -141,6 +143,8 @@ type VirtualMachine struct {
 	NetworkPerf string `json:"networkPerf"`
 	// NetworkPerfCat holds the network performance category
 	NetworkPerfCat string `json:"networkPerfCategory"`
+	// CurrentGen the vm is of current generation
+	CurrentGen bool `json:"currentGen"`
 }
 
 func (v *VirtualMachine) getAttrValue(attr string) float64 {
@@ -152,80 +156,6 @@ func (v *VirtualMachine) getAttrValue(attr string) float64 {
 	default:
 		return 0
 	}
-}
-
-type vmFilter func(vm VirtualMachine, req ClusterRecommendationReq) bool
-
-func (e *Engine) minMemRatioFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
-	minMemToCpuRatio := req.SumMem / req.SumCpu
-	if vm.Mem/vm.Cpus < minMemToCpuRatio {
-		return false
-	}
-	return true
-}
-
-func (e *Engine) burstFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
-	// if not specified in req or it's allowed the filter passes
-	if (req.AllowBurst == nil) || *(req.AllowBurst) {
-		return true
-	}
-	// burst is not allowed
-	return !vm.Burst
-}
-
-func (e *Engine) minCpuRatioFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
-	minCpuToMemRatio := req.SumCpu / req.SumMem
-	if vm.Cpus/vm.Mem < minCpuToMemRatio {
-		return false
-	}
-	return true
-}
-
-func (e *Engine) ntwPerformanceFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
-	if req.NetworkPerf == nil { //there is no filter set
-		return true
-	}
-	if vm.NetworkPerfCat == *req.NetworkPerf { //the network performance category matches the vm
-		return true
-	}
-	return false
-}
-
-// excludeFilter checks for the vm type in the request' exclude list, the filter  passes if the type is not excluded
-func (e *Engine) excludesFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
-	if req.Excludes == nil || len(req.Excludes) == 0 {
-		log.Debugf("no blacklist provided - all vm types are welcome")
-		return true
-	}
-	if contains(req.Excludes, vm.Type) {
-		log.Debugf("the vm type [%s] is blacklisted", vm.Type)
-		return false
-	}
-	return true
-}
-
-// includesFilter checks whether the vm type is in the includes list; the filter passes if the type is in the list
-func (e *Engine) includesFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
-	if req.Includes == nil || len(req.Includes) == 0 {
-		log.Debugf("no whitelist specified - all vm types are welcome")
-		return true
-	}
-	if contains(req.Includes, vm.Type) {
-		log.Debugf("the vm type [%s] is whitelisted", vm.Type)
-		return true
-	}
-	return false
-}
-
-// filterSpots selects vm-s that potentially can be part of "spot" node pools
-func (e *Engine) filterSpots(vms []VirtualMachine) []VirtualMachine {
-	fvms := make([]VirtualMachine, 0)
-	for _, vm := range vms {
-		if vm.AvgPrice != 0 {
-			fvms = append(fvms, vm)
-		}
-	}
-	return fvms
 }
 
 // ByAvgPricePerCpu type for custom sorting of a slice of vms
@@ -514,6 +444,7 @@ func (e *Engine) findVmsWithAttrValues(provider string, region string, zones []s
 				Burst:          p.Burst,
 				NetworkPerf:    p.NtwPerf,
 				NetworkPerfCat: p.NtwPerfCat,
+				CurrentGen:     p.CurrentGen,
 			}
 			vms = append(vms, vm)
 		}
@@ -578,9 +509,9 @@ func (e *Engine) RecommendAttrValues(provider string, region string, attr string
 func (e *Engine) filtersForAttr(attr string) ([]vmFilter, error) {
 	switch attr {
 	case Cpu:
-		return []vmFilter{e.ntwPerformanceFilter, e.minMemRatioFilter, e.burstFilter, e.includesFilter, e.excludesFilter}, nil
+		return []vmFilter{e.currentGenFilter, e.ntwPerformanceFilter, e.minMemRatioFilter, e.burstFilter, e.includesFilter, e.excludesFilter}, nil
 	case Memory:
-		return []vmFilter{e.ntwPerformanceFilter, e.minCpuRatioFilter, e.burstFilter, e.includesFilter, e.excludesFilter}, nil
+		return []vmFilter{e.currentGenFilter, e.ntwPerformanceFilter, e.minCpuRatioFilter, e.burstFilter, e.includesFilter, e.excludesFilter}, nil
 	default:
 		return nil, fmt.Errorf("unsupported attribute: [%s]", attr)
 	}

--- a/pkg/recommender/engine_test.go
+++ b/pkg/recommender/engine_test.go
@@ -58,6 +58,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 		return []*models.ProductDetails{
 			{
 				Type:          "type-1",
+				CurrentGen:    true,
 				OnDemandPrice: 0.68,
 				Cpus:          16,
 				Mem:           32,
@@ -68,6 +69,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 		return []*models.ProductDetails{
 			{
 				Type:          "type-3",
+				CurrentGen:    true,
 				OnDemandPrice: 0.023,
 				Cpus:          1,
 				Mem:           2,
@@ -75,6 +77,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 			},
 			{
 				Type:          "type-4",
+				CurrentGen:    true,
 				OnDemandPrice: 0.096,
 				Cpus:          2,
 				Mem:           4,
@@ -82,6 +85,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 			},
 			{
 				Type:          "type-5",
+				CurrentGen:    true,
 				OnDemandPrice: 0.046,
 				Cpus:          2,
 				Mem:           4,
@@ -89,6 +93,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 			},
 			{
 				Type:          "type-6",
+				CurrentGen:    true,
 				OnDemandPrice: 0.096,
 				Cpus:          2,
 				Mem:           8,
@@ -96,6 +101,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 			},
 			{
 				Type:          "type-7",
+				CurrentGen:    true,
 				OnDemandPrice: 0.17,
 				Cpus:          4,
 				Mem:           8,
@@ -103,6 +109,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 			},
 			{
 				Type:          "type-8",
+				CurrentGen:    true,
 				OnDemandPrice: 0.186,
 				Cpus:          4,
 				Mem:           16,
@@ -110,6 +117,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 			},
 			{
 				Type:          "type-9",
+				CurrentGen:    true,
 				OnDemandPrice: 0.34,
 				Cpus:          8,
 				Mem:           16,
@@ -117,6 +125,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 			},
 			{
 				Type:          "type-10",
+				CurrentGen:    true,
 				OnDemandPrice: 0.68,
 				Cpus:          16,
 				Mem:           32,
@@ -124,6 +133,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 			},
 			{
 				Type:          "type-11",
+				CurrentGen:    true,
 				OnDemandPrice: 0.91,
 				Cpus:          16,
 				Mem:           64,
@@ -131,6 +141,7 @@ func (piCli *dummyProductInfoSource) GetProductDetails(provider string, region s
 			},
 			{
 				Type:          "type-12",
+				CurrentGen:    true,
 				OnDemandPrice: 1.872,
 				Cpus:          32,
 				Mem:           128,

--- a/pkg/recommender/filters.go
+++ b/pkg/recommender/filters.go
@@ -1,0 +1,89 @@
+package recommender
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+type vmFilter func(vm VirtualMachine, req ClusterRecommendationReq) bool
+
+func (e *Engine) minMemRatioFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
+	minMemToCpuRatio := req.SumMem / req.SumCpu
+	if vm.Mem/vm.Cpus < minMemToCpuRatio {
+		return false
+	}
+	return true
+}
+
+func (e *Engine) burstFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
+	// if not specified in req or it's allowed the filter passes
+	if (req.AllowBurst == nil) || *(req.AllowBurst) {
+		return true
+	}
+	// burst is not allowed
+	return !vm.Burst
+}
+
+func (e *Engine) minCpuRatioFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
+	minCpuToMemRatio := req.SumCpu / req.SumMem
+	if vm.Cpus/vm.Mem < minCpuToMemRatio {
+		return false
+	}
+	return true
+}
+
+func (e *Engine) ntwPerformanceFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
+	if req.NetworkPerf == nil { //there is no filter set
+		return true
+	}
+	if vm.NetworkPerfCat == *req.NetworkPerf { //the network performance category matches the vm
+		return true
+	}
+	return false
+}
+
+// excludeFilter checks for the vm type in the request' exclude list, the filter  passes if the type is not excluded
+func (e *Engine) excludesFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
+	if req.Excludes == nil || len(req.Excludes) == 0 {
+		log.Debugf("no blacklist provided - all vm types are welcome")
+		return true
+	}
+	if contains(req.Excludes, vm.Type) {
+		log.Debugf("the vm type [%s] is blacklisted", vm.Type)
+		return false
+	}
+	return true
+}
+
+// includesFilter checks whether the vm type is in the includes list; the filter passes if the type is in the list
+func (e *Engine) includesFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
+	if req.Includes == nil || len(req.Includes) == 0 {
+		log.Debugf("no whitelist specified - all vm types are welcome")
+		return true
+	}
+	if contains(req.Includes, vm.Type) {
+		log.Debugf("the vm type [%s] is whitelisted", vm.Type)
+		return true
+	}
+	return false
+}
+
+// filterSpots selects vm-s that potentially can be part of "spot" node pools
+func (e *Engine) filterSpots(vms []VirtualMachine) []VirtualMachine {
+	fvms := make([]VirtualMachine, 0)
+	for _, vm := range vms {
+		if vm.AvgPrice != 0 {
+			fvms = append(fvms, vm)
+		}
+	}
+	return fvms
+}
+
+// currentGenFilter removes instance types that are not the current generation (amazon only)
+func (e *Engine) currentGenFilter(vm VirtualMachine, req ClusterRecommendationReq) bool {
+	if req.AllowOlderGen == nil || !*req.AllowOlderGen {
+		// filter by current generation by default (if it's not specified in the request) or it's explicitly set to false
+		return vm.CurrentGen
+	}
+	// the flag it's set into the req AND ist's true
+	return true
+}

--- a/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models/product_details.go
+++ b/vendor/github.com/banzaicloud/productinfo/pkg/productinfo-client/models/product_details.go
@@ -24,6 +24,9 @@ type ProductDetails struct {
 	// cpus
 	Cpus float64 `json:"cpusPerVm,omitempty"`
 
+	// CurrentGen signals whether the instance type generation is the current one. Only applies for amazon
+	CurrentGen bool `json:"currentGen,omitempty"`
+
 	// gpus
 	Gpus float64 `json:"gpusPerVm,omitempty"`
 


### PR DESCRIPTION
fixes #132 
- current generation instance types recommended by default (applies to ec2)
- providers other than ec2  - all instance types considered of  "current generation"
- recommendation request extended to control this behaviour ("allowOlderGen" request attribute)
- added unit test for the current-generation filtering logic
- ran swagger to reflect api changes
- tested locally