### PR TITLE
ondemandpct ignored when spot pools not supported by the provider (or…

### DIFF
--- a/pkg/recommender/filters.go
+++ b/pkg/recommender/filters.go
@@ -69,6 +69,7 @@ func (e *Engine) includesFilter(vm VirtualMachine, req ClusterRecommendationReq)
 
 // filterSpots selects vm-s that potentially can be part of "spot" node pools
 func (e *Engine) filterSpots(vms []VirtualMachine) []VirtualMachine {
+	log.Debugf("selecting spot instances for recommending spot pools")
 	fvms := make([]VirtualMachine, 0)
 	for _, vm := range vms {
 		if vm.AvgPrice != 0 {


### PR DESCRIPTION
…acle)
Spot instances are not supported by oracle this ondemandpct is ignored in the recommendation request. (it's implicitly considered to be 100)

Issue is to be raised for adding validation or other solution to signal the behaviour through the API