### PR TITLE
Scaling out to a desired state

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ The `Banzai Cloud Telescopes` is a cluster recommender application; its main pur
 
 ## Quick start
 
-Building the project is as simple as running a go build command. The result is a statically linked executable binary.
+Building the project is as simple as running a `make build` command. The result is a statically linked executable binary in the `./build` directory.
 
 ```
-go build .
+make build
 ```
 
 The application can be started with the following arguments:
 
 ```
-Usage of ./telescopes:
+Usage of ./build/telescopes:
       --cloudinfo-address string   the address of the Cloud Info service to retrieve attribute and pricing info [format=scheme://host:port/basepath] (default "http://localhost:9090/api/v1")
       --dev-mode                   development mode, if true token based authentication is disabled, false by default
       --help                       print usage

--- a/api/openapi-spec/recommender.json
+++ b/api/openapi-spec/recommender.json
@@ -20,6 +20,78 @@
   "basePath": "/api/v1",
   "paths": {
     "/recommender/:provider/:region/cluster": {
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http"
+        ],
+        "tags": [
+          "recommend"
+        ],
+        "summary": "Provides a recommendation for a scale-out, based on a current cluster layout on a given provider in a specific region.",
+        "operationId": "recommendClusterScaleOut",
+        "parameters": [
+          {
+            "type": "integer",
+            "format": "int64",
+            "x-go-name": "DesiredGpu",
+            "description": "Total desired number of GPUs in the cluster after the scale out",
+            "name": "desiredCpu",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "x-go-name": "OnDemandPct",
+            "description": "Percentage of regular (on-demand) nodes among the scale out nodes",
+            "name": "onDemandPct",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "x-go-name": "Zones",
+            "description": "Availability zones to be included in the recommendation",
+            "name": "zones",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "x-go-name": "Excludes",
+            "description": "Excludes is a blacklist - a slice with vm types to be excluded from the recommendation",
+            "name": "excludes",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/NodePoolDesc"
+            },
+            "x-go-name": "ActualLayout",
+            "description": "Description of the current cluster layout",
+            "name": "actualLayout",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "RecommendationResponse",
+            "schema": {
+              "$ref": "#/definitions/RecommendationResponse"
+            }
+          }
+        }
+      },
       "post": {
         "consumes": [
           "application/json"
@@ -36,6 +108,27 @@
         "summary": "Provides a recommended set of node pools on a given provider in a specific region.",
         "operationId": "recommendClusterSetup",
         "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Provider",
+            "name": "provider",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Service",
+            "name": "service",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Region",
+            "name": "region",
+            "in": "path",
+            "required": true
+          },
           {
             "type": "number",
             "format": "double",
@@ -141,27 +234,6 @@
             "description": "AllowOlderGen allow older generations of virtual machines (applies for EC2 only)",
             "name": "allowOlderGen",
             "in": "query"
-          },
-          {
-            "type": "string",
-            "x-go-name": "Provider",
-            "name": "provider",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Service",
-            "name": "service",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Region",
-            "name": "region",
-            "in": "path",
-            "required": true
           }
         ],
         "responses": {
@@ -210,6 +282,13 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/VirtualMachine"
+      },
+      "x-go-package": "github.com/banzaicloud/telescopes/pkg/recommender"
+    },
+    "ByNonZeroNodePools": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/NodePool"
       },
       "x-go-package": "github.com/banzaicloud/telescopes/pkg/recommender"
     },
@@ -363,9 +442,47 @@
       },
       "x-go-package": "github.com/banzaicloud/telescopes/pkg/recommender"
     },
-    "ClusterRecommender": {
-      "description": "ClusterRecommender defines operations for cluster recommendations",
+    "ClusterScaleoutRecommendationReq": {
+      "description": "ClusterRecommendationReq encapsulates the recommendation input data",
       "type": "object",
+      "properties": {
+        "actualLayout": {
+          "description": "Description of the current cluster layout",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NodePoolDesc"
+          },
+          "x-go-name": "ActualLayout"
+        },
+        "desiredCpu": {
+          "description": "Total desired number of GPUs in the cluster after the scale out",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "DesiredGpu"
+        },
+        "excludes": {
+          "description": "Excludes is a blacklist - a slice with vm types to be excluded from the recommendation",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Excludes"
+        },
+        "onDemandPct": {
+          "description": "Percentage of regular (on-demand) nodes among the scale out nodes",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "OnDemandPct"
+        },
+        "zones": {
+          "description": "Availability zones to be included in the recommendation",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Zones"
+        }
+      },
       "x-go-package": "github.com/banzaicloud/telescopes/pkg/recommender"
     },
     "Engine": {
@@ -535,6 +652,28 @@
         },
         "vmClass": {
           "description": "Specifies if the recommended node pool consists of regular or spot/preemptible instance types",
+          "type": "string",
+          "x-go-name": "VmClass"
+        }
+      },
+      "x-go-package": "github.com/banzaicloud/telescopes/pkg/recommender"
+    },
+    "NodePoolDesc": {
+      "type": "object",
+      "properties": {
+        "instanceType": {
+          "description": "Instance type of VMs in the node pool",
+          "type": "string",
+          "x-go-name": "InstanceType"
+        },
+        "sumNodes": {
+          "description": "Number of VMs in the node pool",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "SumNodes"
+        },
+        "vmClass": {
+          "description": "Signals that the node pool consists of regular or spot/preemptible instance types",
           "type": "string",
           "x-go-name": "VmClass"
         }

--- a/api/openapi-spec/recommender.yaml
+++ b/api/openapi-spec/recommender.yaml
@@ -17,6 +17,61 @@ info:
   version: 0.0.1
 paths:
   '/recommender/:provider/:region/cluster':
+    put:
+      tags:
+        - recommend
+      summary: >-
+        Provides a recommendation for a scale-out, based on a current cluster
+        layout on a given provider in a specific region.
+      operationId: recommendClusterScaleOut
+      parameters:
+        - x-go-name: DesiredGpu
+          description: Total desired number of GPUs in the cluster after the scale out
+          name: desiredCpu
+          in: query
+          schema:
+            type: integer
+            format: int64
+        - x-go-name: OnDemandPct
+          description: Percentage of regular (on-demand) nodes among the scale out nodes
+          name: onDemandPct
+          in: query
+          schema:
+            type: integer
+            format: int64
+        - x-go-name: Zones
+          description: Availability zones to be included in the recommendation
+          name: zones
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+        - x-go-name: Excludes
+          description: >-
+            Excludes is a blacklist - a slice with vm types to be excluded from
+            the recommendation
+          name: excludes
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+        - x-go-name: ActualLayout
+          description: Description of the current cluster layout
+          name: actualLayout
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/NodePoolDesc'
+      responses:
+        '200':
+          description: RecommendationResponse
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendationResponse'
     post:
       tags:
         - recommend
@@ -25,6 +80,24 @@ paths:
         specific region.
       operationId: recommendClusterSetup
       parameters:
+        - x-go-name: Provider
+          name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+        - x-go-name: Service
+          name: service
+          in: path
+          required: true
+          schema:
+            type: string
+        - x-go-name: Region
+          name: region
+          in: path
+          required: true
+          schema:
+            type: string
         - x-go-name: SumCpu
           description: Total number of CPUs requested for the cluster
           name: sumCpu
@@ -121,24 +194,6 @@ paths:
           in: query
           schema:
             type: boolean
-        - x-go-name: Provider
-          name: provider
-          in: path
-          required: true
-          schema:
-            type: string
-        - x-go-name: Service
-          name: service
-          in: path
-          required: true
-          schema:
-            type: string
-        - x-go-name: Region
-          name: region
-          in: path
-          required: true
-          schema:
-            type: string
       responses:
         '200':
           description: RecommendationResponse
@@ -178,6 +233,11 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/VirtualMachine'
+      x-go-package: github.com/banzaicloud/telescopes/pkg/recommender
+    ByNonZeroNodePools:
+      type: array
+      items:
+        $ref: '#/components/schemas/NodePool'
       x-go-package: github.com/banzaicloud/telescopes/pkg/recommender
     ClusterRecommendationAccuracy:
       description: ClusterRecommendationAccuracy encapsulates recommendation accuracy
@@ -305,9 +365,40 @@ components:
             type: string
           x-go-name: Zones
       x-go-package: github.com/banzaicloud/telescopes/pkg/recommender
-    ClusterRecommender:
-      description: ClusterRecommender defines operations for cluster recommendations
+    ClusterScaleoutRecommendationReq:
+      description: ClusterRecommendationReq encapsulates the recommendation input data
       type: object
+      properties:
+        actualLayout:
+          description: Description of the current cluster layout
+          type: array
+          items:
+            $ref: '#/components/schemas/NodePoolDesc'
+          x-go-name: ActualLayout
+        desiredCpu:
+          description: Total desired number of GPUs in the cluster after the scale out
+          type: integer
+          format: int64
+          x-go-name: DesiredGpu
+        excludes:
+          description: >-
+            Excludes is a blacklist - a slice with vm types to be excluded from
+            the recommendation
+          type: array
+          items:
+            type: string
+          x-go-name: Excludes
+        onDemandPct:
+          description: Percentage of regular (on-demand) nodes among the scale out nodes
+          type: integer
+          format: int64
+          x-go-name: OnDemandPct
+        zones:
+          description: Availability zones to be included in the recommendation
+          type: array
+          items:
+            type: string
+          x-go-name: Zones
       x-go-package: github.com/banzaicloud/telescopes/pkg/recommender
     Engine:
       description: >-
@@ -460,6 +551,25 @@ components:
           description: >-
             Specifies if the recommended node pool consists of regular or
             spot/preemptible instance types
+          type: string
+          x-go-name: VmClass
+      x-go-package: github.com/banzaicloud/telescopes/pkg/recommender
+    NodePoolDesc:
+      type: object
+      properties:
+        instanceType:
+          description: Instance type of VMs in the node pool
+          type: string
+          x-go-name: InstanceType
+        sumNodes:
+          description: Number of VMs in the node pool
+          type: integer
+          format: int64
+          x-go-name: SumNodes
+        vmClass:
+          description: >-
+            Signals that the node pool consists of regular or spot/preemptible
+            instance types
           type: string
           x-go-name: VmClass
       x-go-package: github.com/banzaicloud/telescopes/pkg/recommender


### PR DESCRIPTION
Changed scale out API to accept a desired state instead of the additional resources.
Can't recommend "scale in" for now (not sure if it's a requirement later). If desired resources are less than the current total resources in the cluster, an error is returned.

example `curl` for scaling out:
```
curl -X PUT -d '{"DesiredMem":152, "DesiredCpu":52, "OnDemandPct":10, "actualLayout":[{"instanceType": "m5.xlarge", "vmClass":"ondemand", "sumNodes":2},{"instanceType": "m5.2xlarge", "vmClass":"spot", "sumNodes":2},{"instanceType": "c5.2xlarge", "vmClass":"spot", "sumNodes":2},{"instanceType": "c5.xlarge", "vmClass":"spot", "sumNodes":2}], "Excludes": ["m5.2xlarge"]}' "localhost:9091/api/v1/recommender/amazon/eks/eu-west-1/cluster" | jq .
```

also fixed two bugs:

1. Number of spot node pools was computed based on the total number of instances in the cluster instead of the number of spot nodes only - it caused that a very large number of empty node pools appeared in the response when on-demand percentage was high and node count was also high

2. Requested spot resources was computed based on the on-demand percentage only, instead of the actual number of on-demand resources already filled up. When recommending a small cluster it caused that more resources was added then required. 

e.g.: requested 4 cpus, min od pct: 60%
- before the fix: min required on-demand cpu: 2.4, min required spot: 1.6. Finds `t2.xlarge` (4 cpus) for on-demand, that satisfies the 2.4 requirement, and finds `t2.large` for spots that satisfies the 1.6 requirement. Total CPU recommended: 6 instead of 4
- after the fix:  min required on-demand cpu: 2.4. Finds `t2.xlarge` (4 cpus) for on-demand. Computes spot resources needed: total(4)-ondemand(4) = 0. Will only recommend 0 sized spot nodepools, total CPU recommended: 4
- this was even more painful than this example when scaling out with a small amount of resources - where nodepools are fixed and can't always recommend a very small and cheap instance type like `t2.large`