### PR TITLE
reduced the recommendation time

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -851,7 +851,6 @@
   input-imports = [
     "github.com/banzaicloud/bank-vaults/auth",
     "github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client",
-    "github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client/attribute",
     "github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client/products",
     "github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client/provider",
     "github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client/region",

--- a/pkg/recommender/product.go
+++ b/pkg/recommender/product.go
@@ -16,7 +16,6 @@ package recommender
 
 import (
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client"
-	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client/attribute"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client/products"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client/provider"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/client/region"
@@ -28,12 +27,6 @@ import (
 
 // CloudInfoSource declares operations for retrieving information required for the recommender engine
 type CloudInfoSource interface {
-	// GetAttributeValues retrieves attribute values based on the given arguments
-	GetAttributeValues(provider string, service string, region string, attr string) ([]float64, error)
-
-	// GetZones describes the given region fof the given provider
-	GetZones(provider string, service string, region string) ([]string, error)
-
 	// GetProductDetails retrieves the product details for the provider and region
 	GetProductDetails(provider string, service string, region string) ([]*models.ProductDetails, error)
 }
@@ -52,28 +45,6 @@ const (
 // NewCloudInfoClient creates a new product info client wrapper instance
 func NewCloudInfoClient(pic *client.Cloudinfo) *CloudInfoClient {
 	return &CloudInfoClient{Cloudinfo: pic}
-}
-
-// GetAttributeValues retrieves available attribute values on the provider in the region for the attribute
-func (ciCli *CloudInfoClient) GetAttributeValues(provider string, service string, region string, attr string) ([]float64, error) {
-	attrParams := attribute.NewGetAttrValuesParams().WithProvider(provider).WithRegion(region).WithAttribute(attr).WithService(service)
-
-	allValues, err := ciCli.Attribute.GetAttrValues(attrParams)
-	if err != nil {
-		return nil, discriminateErrCtx(err)
-	}
-	return allValues.Payload.AttributeValues, nil
-}
-
-// GetZones describes the region (eventually returns the zones in the region)
-func (ciCli *CloudInfoClient) GetZones(prv string, svc string, reg string) ([]string, error) {
-	grp := region.NewGetRegionParams().WithProvider(prv).WithService(svc).WithRegion(reg)
-
-	r, err := ciCli.Region.GetRegion(grp)
-	if err != nil {
-		return nil, discriminateErrCtx(err)
-	}
-	return r.Payload.Zones, nil
 }
 
 // GetProductDetails gets the available product details from the provider in the region

--- a/pkg/recommender/vms/filters.go
+++ b/pkg/recommender/vms/filters.go
@@ -26,21 +26,15 @@ type vmFilter func(vm recommender.VirtualMachine, req recommender.ClusterRecomme
 func (s *vmSelector) filtersForAttr(attr string, provider string, req recommender.ClusterRecommendationReq) ([]vmFilter, error) {
 	var filters []vmFilter
 	// generic filters - not depending on providers and attributes
-	if req.Includes == nil || len(req.Includes) == 0 {
-		s.log.Debug("no whitelist specified - all vm types are welcome")
-	} else {
+	if len(req.Includes) != 0 {
 		filters = append(filters, s.includesFilter)
 	}
 
-	if req.Excludes == nil || len(req.Excludes) == 0 {
-		s.log.Debug("no blacklist provided - all vm types are welcome")
-	} else {
+	if len(req.Excludes) != 0 {
 		filters = append(filters, s.excludesFilter)
 	}
 
-	if req.Category == nil || len(req.Category) == 0 {
-		s.log.Debug("no category specified - all vm types are welcome")
-	} else {
+	if len(req.Category) != 0 {
 		filters = append(filters, s.categoryFilter)
 	}
 
@@ -73,6 +67,7 @@ func (s *vmSelector) filtersForAttr(attr string, provider string, req recommende
 		return nil, emperror.With(errors.New("unsupported attribute"), "attribute", attr)
 	}
 
+	s.log.Debug("filters are successfully registered", map[string]interface{}{"numberOfFilters": len(filters)})
 	return filters, nil
 }
 

--- a/pkg/recommender/vms/filters.go
+++ b/pkg/recommender/vms/filters.go
@@ -23,16 +23,44 @@ import (
 type vmFilter func(vm recommender.VirtualMachine, req recommender.ClusterRecommendationReq) bool
 
 // filtersForAttr returns the slice for
-func (s *vmSelector) filtersForAttr(attr string, provider string) ([]vmFilter, error) {
+func (s *vmSelector) filtersForAttr(attr string, provider string, req recommender.ClusterRecommendationReq) ([]vmFilter, error) {
+	var filters []vmFilter
 	// generic filters - not depending on providers and attributes
-	var filters = []vmFilter{s.includesFilter, s.excludesFilter, s.categoryFilter}
+	if req.Includes == nil || len(req.Includes) == 0 {
+		s.log.Debug("no whitelist specified - all vm types are welcome")
+	} else {
+		filters = append(filters, s.includesFilter)
+	}
+
+	if req.Excludes == nil || len(req.Excludes) == 0 {
+		s.log.Debug("no blacklist provided - all vm types are welcome")
+	} else {
+		filters = append(filters, s.excludesFilter)
+	}
+
+	if req.Category == nil || len(req.Category) == 0 {
+		s.log.Debug("no category specified - all vm types are welcome")
+	} else {
+		filters = append(filters, s.categoryFilter)
+	}
 
 	// provider specific filters
 	switch provider {
 	case "amazon":
-		filters = append(filters, s.currentGenFilter, s.burstFilter, s.ntwPerformanceFilter)
+		if req.NetworkPerf != nil {
+			filters = append(filters, s.ntwPerformanceFilter)
+		}
+		// burst is not allowed
+		if req.AllowBurst != nil && !*req.AllowBurst {
+			filters = append(filters, s.burstFilter)
+		}
+		if req.AllowOlderGen == nil || !*req.AllowOlderGen {
+			filters = append(filters, s.currentGenFilter)
+		}
 	case "google", "alibaba":
-		filters = append(filters, s.ntwPerformanceFilter)
+		if req.NetworkPerf != nil {
+			filters = append(filters, s.ntwPerformanceFilter)
+		}
 	}
 
 	// attribute specific filters
@@ -66,11 +94,6 @@ func (s *vmSelector) minMemRatioFilter(vm recommender.VirtualMachine, req recomm
 }
 
 func (s *vmSelector) burstFilter(vm recommender.VirtualMachine, req recommender.ClusterRecommendationReq) bool {
-	// if not specified in req or it's allowed the filter passes
-	if (req.AllowBurst == nil) || *(req.AllowBurst) {
-		return true
-	}
-	// burst is not allowed
 	return !vm.Burst
 }
 
@@ -80,31 +103,15 @@ func (s *vmSelector) minCpuRatioFilter(vm recommender.VirtualMachine, req recomm
 }
 
 func (s *vmSelector) ntwPerformanceFilter(vm recommender.VirtualMachine, req recommender.ClusterRecommendationReq) bool {
-	if req.NetworkPerf == nil { //there is no filter set
-		return true
-	}
-	if vm.NetworkPerfCat == *req.NetworkPerf { //the network performance category matches the vm
-		return true
-	}
-	return false
+	return vm.NetworkPerfCat == *req.NetworkPerf
 }
 
 func (s *vmSelector) categoryFilter(vm recommender.VirtualMachine, req recommender.ClusterRecommendationReq) bool {
-	if req.Category == nil || len(req.Category) == 0 {
-		return true
-	}
-	if s.contains(req.Category, vm.Category) {
-		return true
-	}
-	return false
+	return s.contains(req.Category, vm.Category)
 }
 
 // excludeFilter checks for the vm type in the request' exclude list, the filter  passes if the type is not excluded
 func (s *vmSelector) excludesFilter(vm recommender.VirtualMachine, req recommender.ClusterRecommendationReq) bool {
-	if req.Excludes == nil || len(req.Excludes) == 0 {
-		s.log.Debug("no blacklist provided - all vm types are welcome")
-		return true
-	}
 	if s.contains(req.Excludes, vm.Type) {
 		s.log.Debug("the vm type is blacklisted", map[string]interface{}{"type": vm.Type})
 		return false
@@ -114,10 +121,6 @@ func (s *vmSelector) excludesFilter(vm recommender.VirtualMachine, req recommend
 
 // includesFilter checks whether the vm type is in the includes list; the filter passes if the type is in the list
 func (s *vmSelector) includesFilter(vm recommender.VirtualMachine, req recommender.ClusterRecommendationReq) bool {
-	if req.Includes == nil || len(req.Includes) == 0 {
-		s.log.Debug("no whitelist specified - all vm types are welcome")
-		return true
-	}
 	if s.contains(req.Includes, vm.Type) {
 		s.log.Debug("the vm type is whitelisted", map[string]interface{}{"type": vm.Type})
 		return true
@@ -139,12 +142,8 @@ func (s *vmSelector) filterSpots(vms []recommender.VirtualMachine) []recommender
 
 // currentGenFilter removes instance types that are not the current generation (amazon only)
 func (s *vmSelector) currentGenFilter(vm recommender.VirtualMachine, req recommender.ClusterRecommendationReq) bool {
-	if req.AllowOlderGen == nil || !*req.AllowOlderGen {
-		// filter by current generation by default (if it's not specified in the request) or it's explicitly set to false
-		return vm.CurrentGen
-	}
-	// the flag it's set into the req AND it's true
-	return true
+	// filter by current generation
+	return vm.CurrentGen
 }
 
 // contains is a helper function to check if a slice contains a string

--- a/pkg/recommender/vms/recommender.go
+++ b/pkg/recommender/vms/recommender.go
@@ -41,7 +41,7 @@ func (s *vmSelector) RecommendVms(provider string, vms []recommender.VirtualMach
 	s.log = log
 	s.log.Info("recommending virtual machines", map[string]interface{}{"attribute": attr})
 
-	vmFilters, err := s.filtersForAttr(attr, provider)
+	vmFilters, err := s.filtersForAttr(attr, provider, req)
 	if err != nil {
 		return nil, nil, emperror.Wrap(err, "failed to identify filters")
 	}

--- a/pkg/recommender/vms/recommender_test.go
+++ b/pkg/recommender/vms/recommender_test.go
@@ -20,150 +20,90 @@ import (
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo-client/models"
 	"github.com/banzaicloud/telescopes/pkg/recommender"
 	"github.com/goph/logur"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	OutOfLimits         = "2 values between 10 - 20"
-	LargerValues        = "all values are larger than 20, return the closest value"
-	SmallerValues       = "all values are less than 10, return the closest value"
-	MinLargerThanMax    = "error, min > max"
-	Error               = "error returned"
-	DescribeRegionError = "could not describe region"
-	ProductDetailsError = "could not get product details"
-	AvgPriceNil         = "average price is nil"
-)
-
-type dummyCloudInfoSource struct {
-	// test case id to drive the behaviour
-	TcId string
-}
-
-func (piCli *dummyCloudInfoSource) GetAttributeValues(provider string, service string, region string, attr string) ([]float64, error) {
-	switch piCli.TcId {
-	case OutOfLimits:
-		return []float64{8, 13, 14, 6}, nil
-	case LargerValues:
-		return []float64{30, 40, 50, 60}, nil
-	case SmallerValues:
-		return []float64{1, 2, 3, 5, 9}, nil
-	case MinLargerThanMax:
-		return []float64{1}, nil
-	case Error:
-		return nil, errors.New(Error)
-	}
-	return []float64{15, 16, 17}, nil
-}
-
-func (piCli *dummyCloudInfoSource) GetZones(provider string, service string, region string) ([]string, error) {
-	switch piCli.TcId {
-	case DescribeRegionError:
-		return nil, errors.New(DescribeRegionError)
-	default:
-		return []string{"dummyZone1", "dummyZone2", "dummyZone3"}, nil
-	}
-}
-
-func (piCli *dummyCloudInfoSource) GetProductDetails(provider string, service string, region string) ([]*models.ProductDetails, error) {
-	switch piCli.TcId {
-	case ProductDetailsError:
-		return nil, errors.New(ProductDetailsError)
-	case AvgPriceNil:
-		return []*models.ProductDetails{
-			{
-				Type:          "type-1",
-				CurrentGen:    true,
-				OnDemandPrice: 0.68,
-				Cpus:          16,
-				Mem:           32,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.171, Zone: "invalidZone"}},
-			},
-		}, nil
-	default:
-		return []*models.ProductDetails{
-			{
-				Type:          "type-3",
-				CurrentGen:    true,
-				OnDemandPrice: 0.023,
-				Cpus:          1,
-				Mem:           2,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.0069, Zone: "dummyZone1"}},
-			},
-			{
-				Type:          "type-4",
-				CurrentGen:    true,
-				OnDemandPrice: 0.096,
-				Cpus:          2,
-				Mem:           4,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.018, Zone: "dummyZone2"}},
-			},
-			{
-				Type:          "type-5",
-				CurrentGen:    true,
-				OnDemandPrice: 0.046,
-				Cpus:          2,
-				Mem:           4,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.014, Zone: "dummyZone2"}},
-			},
-			{
-				Type:          "type-6",
-				CurrentGen:    true,
-				OnDemandPrice: 0.096,
-				Cpus:          2,
-				Mem:           8,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.02, Zone: "dummyZone1"}},
-			},
-			{
-				Type:          "type-7",
-				CurrentGen:    true,
-				OnDemandPrice: 0.17,
-				Cpus:          4,
-				Mem:           8,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.037, Zone: "dummyZone3"}},
-			},
-			{
-				Type:          "type-8",
-				CurrentGen:    true,
-				OnDemandPrice: 0.186,
-				Cpus:          4,
-				Mem:           16,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.056, Zone: "dummyZone2"}},
-			},
-			{
-				Type:          "type-9",
-				CurrentGen:    true,
-				OnDemandPrice: 0.34,
-				Cpus:          8,
-				Mem:           16,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.097, Zone: "dummyZone1"}},
-			},
-			{
-				Type:          "type-10",
-				CurrentGen:    true,
-				OnDemandPrice: 0.68,
-				Cpus:          16,
-				Mem:           32,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.171, Zone: "dummyZone2"}},
-			},
-			{
-				Type:          "type-11",
-				CurrentGen:    true,
-				OnDemandPrice: 0.91,
-				Cpus:          16,
-				Mem:           64,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.157, Zone: "dummyZone1"}},
-			},
-			{
-				Type:          "type-12",
-				CurrentGen:    true,
-				OnDemandPrice: 1.872,
-				Cpus:          32,
-				Mem:           128,
-				SpotPrice:     []*models.ZonePrice{{Price: 0.66, Zone: "dummyZone3"}},
-			},
-		}, nil
-	}
+var productDetails = []*models.ProductDetails{
+	{
+		Type:          "type-3",
+		CurrentGen:    true,
+		OnDemandPrice: 0.023,
+		Cpus:          1,
+		Mem:           2,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.0069, Zone: "dummyZone1"}},
+	},
+	{
+		Type:          "type-4",
+		CurrentGen:    true,
+		OnDemandPrice: 0.096,
+		Cpus:          2,
+		Mem:           4,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.018, Zone: "dummyZone2"}},
+	},
+	{
+		Type:          "type-5",
+		CurrentGen:    true,
+		OnDemandPrice: 0.046,
+		Cpus:          2,
+		Mem:           4,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.014, Zone: "dummyZone2"}},
+	},
+	{
+		Type:          "type-6",
+		CurrentGen:    true,
+		OnDemandPrice: 0.096,
+		Cpus:          2,
+		Mem:           8,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.02, Zone: "dummyZone1"}},
+	},
+	{
+		Type:          "type-7",
+		CurrentGen:    true,
+		OnDemandPrice: 0.17,
+		Cpus:          4,
+		Mem:           8,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.037, Zone: "dummyZone3"}},
+	},
+	{
+		Type:          "type-8",
+		CurrentGen:    true,
+		OnDemandPrice: 0.186,
+		Cpus:          4,
+		Mem:           16,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.056, Zone: "dummyZone2"}},
+	},
+	{
+		Type:          "type-9",
+		CurrentGen:    true,
+		OnDemandPrice: 0.34,
+		Cpus:          8,
+		Mem:           16,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.097, Zone: "dummyZone1"}},
+	},
+	{
+		Type:          "type-10",
+		CurrentGen:    true,
+		OnDemandPrice: 0.68,
+		Cpus:          17,
+		Mem:           32,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.171, Zone: "dummyZone2"}},
+	},
+	{
+		Type:          "type-11",
+		CurrentGen:    true,
+		OnDemandPrice: 0.91,
+		Cpus:          16,
+		Mem:           64,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.157, Zone: "dummyZone1"}},
+	},
+	{
+		Type:          "type-12",
+		CurrentGen:    true,
+		OnDemandPrice: 1.872,
+		Cpus:          32,
+		Mem:           128,
+		SpotPrice:     []*models.ZonePrice{{Price: 0.66, Zone: "dummyZone3"}},
+	},
 }
 
 func TestVmSelector_RecommendVms(t *testing.T) {
@@ -221,33 +161,15 @@ func TestVmSelector_RecommendVms(t *testing.T) {
 }
 
 func TestVmSelector_recommendAttrValues(t *testing.T) {
-
 	tests := []struct {
 		name      string
-		pi        recommender.CloudInfoSource
 		request   recommender.ClusterRecommendationReq
 		attribute string
 		check     func([]float64, error)
 	}{
+
 		{
-			name: "all attributes between limits",
-			pi:   &dummyCloudInfoSource{},
-			request: recommender.ClusterRecommendationReq{
-				MinNodes: 5,
-				MaxNodes: 10,
-				SumMem:   100,
-				SumCpu:   100,
-			},
-			attribute: recommender.Cpu,
-			check: func(values []float64, err error) {
-				assert.Nil(t, err, "should not get error when recommending attributes")
-				assert.Equal(t, 3, len(values), "recommended number of values is not as expected")
-				assert.Equal(t, []float64{15, 16, 17}, values)
-			},
-		},
-		{
-			name: "attributes out of limits not recommended",
-			pi:   &dummyCloudInfoSource{OutOfLimits},
+			name: "successfully get recommended attribute values",
 			request: recommender.ClusterRecommendationReq{
 				MinNodes: 5,
 				MaxNodes: 10,
@@ -258,64 +180,15 @@ func TestVmSelector_recommendAttrValues(t *testing.T) {
 			check: func(values []float64, err error) {
 				assert.Nil(t, err, "should not get error when recommending attributes")
 				assert.Equal(t, 2, len(values), "recommended number of values is not as expected")
-
-			},
-		},
-		{
-			name: "no values between limits found - smallest value returned",
-			pi:   &dummyCloudInfoSource{LargerValues},
-			request: recommender.ClusterRecommendationReq{
-				MinNodes: 5,
-				MaxNodes: 10,
-				SumMem:   100,
-				SumCpu:   100,
-			},
-			attribute: recommender.Cpu,
-			check: func(values []float64, err error) {
-				assert.Nil(t, err, "should not get error when recommending attributes")
-				assert.Equal(t, 1, len(values), "recommended number of values is not as expected")
-				assert.Equal(t, float64(30), values[0], "recommended number of values is not as expected")
-
-			},
-		},
-		{
-			name: "no values between limits found - largest value returned",
-			pi:   &dummyCloudInfoSource{SmallerValues},
-			request: recommender.ClusterRecommendationReq{
-				MinNodes: 5,
-				MaxNodes: 10,
-				SumMem:   100,
-				SumCpu:   100,
-			},
-			attribute: recommender.Cpu,
-			check: func(values []float64, err error) {
-				assert.Nil(t, err, "should not get error when recommending attributes")
-				assert.Equal(t, 1, len(values), "recommended number of values is not as expected")
-				assert.Equal(t, float64(9), values[0], "recommended number of values is not as expected")
-
-			},
-		},
-		{
-			name: "error - attribute values could not be retrieved",
-			pi:   &dummyCloudInfoSource{Error},
-			request: recommender.ClusterRecommendationReq{
-				MinNodes: 10,
-				MaxNodes: 10,
-				SumMem:   100,
-				SumCpu:   100,
-			},
-			attribute: recommender.Cpu,
-			check: func(values []float64, err error) {
-				assert.Nil(t, values, "returned attr values should be nils")
-				assert.EqualError(t, err, Error)
+				assert.Equal(t, float64(16), values[0], "recommended number of values is not as expected")
 
 			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			selector := NewVmSelector(logur.NewTestLogger(), test.pi)
-			test.check(selector.recommendAttrValues("dummyProvider", "dummyService", "dummyRegion", test.attribute, test.request))
+			selector := NewVmSelector(logur.NewTestLogger(), nil)
+			test.check(selector.recommendAttrValues(productDetails, test.attribute, test.request))
 		})
 	}
 }


### PR DESCRIPTION
What's in this PR?

 - filters for virtual machines are only registered if necessary
 - the virtual machine attribute list is computed by Telescopes
 - the average spot price is independent of the user-specified zone, so it is not necessary to retrieve from Cloudinfo