### PR TITLE
change multi cluster response key

### DIFF
--- a/pkg/recommender/engine.go
+++ b/pkg/recommender/engine.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	"github.com/goph/emperror"
 	"github.com/goph/logur"
@@ -228,7 +229,8 @@ func (e *Engine) RecommendMultiCluster(req MultiClusterRecommendationReq) (map[s
 			}
 
 			limitedResponses := e.getLimitedResponses(responses, req.RespPerService)
-			respPerService[service] = limitedResponses
+			key := strings.Join([]string{strings.ToLower(provider.Provider), strings.ToUpper(service)}, "")
+			respPerService[key] = limitedResponses
 		}
 	}
 


### PR DESCRIPTION
More PKE services will be supported (eg. Azure PKE), therefore multi cloud response key contains provider and service (eg. amazonPKE)