### PR TITLE
continent validation

### DIFF
--- a/.idea/runConfigurations/Debug.xml
+++ b/.idea/runConfigurations/Debug.xml
@@ -3,7 +3,7 @@
     <module name="telescopes" />
     <working_directory value="$PROJECT_DIR$/" />
     <go_parameters value="-i" />
-    <parameters value="--dev-mode --cloudinfo-address=https://beta.banzaicloud.io/cloudinfo/api/v1 --log-level=debug" />
+    <parameters value="--dev-mode --cloudinfo-address=https://beta.banzaicloud.io/cloudinfo/api/v1 --log-format=logfmt --log-level=debug" />
     <kind value="PACKAGE" />
     <filePath value="$PROJECT_DIR$/" />
     <package value="github.com/banzaicloud/telescopes/cmd/telescopes" />

--- a/cmd/telescopes/main.go
+++ b/cmd/telescopes/main.go
@@ -86,7 +86,7 @@ func main() {
 		map[string]interface{}{"version": version, "commit_hash": commitHash, "build_date": buildDate})
 
 	piUrl := parseCloudInfoAddress(config.Cloudinfo.Address)
-	ciCli := recommender.NewCloudInfoClient(piUrl.String())
+	ciCli := recommender.NewCloudInfoClient(piUrl.String(), logger)
 
 	// configure the gin validator
 	err = api.ConfigureValidator(ciCli)

--- a/cmd/telescopes/main.go
+++ b/cmd/telescopes/main.go
@@ -89,7 +89,7 @@ func main() {
 	ciCli := recommender.NewCloudInfoClient(piUrl.String(), logger)
 
 	// configure the gin validator
-	err = api.ConfigureValidator(ciCli)
+	err = api.ConfigureValidator()
 	emperror.Panic(err)
 
 	vmSelector := vms.NewVmSelector(logger)

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/goph/logur v0.11.0
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
-	github.com/hashicorp/nomad v0.8.7
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/moogar0880/problems v0.0.0-20180130003543-91791093a28a
 	github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/goph/logur v0.11.0
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
+	github.com/hashicorp/nomad v0.8.7
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/moogar0880/problems v0.0.0-20180130003543-91791093a28a
 	github.com/pkg/errors v0.8.1

--- a/internal/app/telescopes/api/routes.go
+++ b/internal/app/telescopes/api/routes.go
@@ -37,12 +37,12 @@ const (
 type RouteHandler struct {
 	engine    recommender.ClusterRecommender
 	buildInfo buildinfo.BuildInfo
-	ciCli     *recommender.CloudInfoClient
+	ciCli     recommender.CloudInfoSource
 	log       logur.Logger
 }
 
 // NewRouteHandler creates a new RouteHandler and returns a reference to it
-func NewRouteHandler(engine recommender.ClusterRecommender, info buildinfo.BuildInfo, ciCli *recommender.CloudInfoClient, log logur.Logger) *RouteHandler {
+func NewRouteHandler(engine recommender.ClusterRecommender, info buildinfo.BuildInfo, ciCli recommender.CloudInfoSource, log logur.Logger) *RouteHandler {
 	return &RouteHandler{
 		engine:    engine,
 		buildInfo: info,

--- a/internal/app/telescopes/api/validate.go
+++ b/internal/app/telescopes/api/validate.go
@@ -126,7 +126,7 @@ func (ppV *pathParamValidator) ValidateContinents(continents []string) error {
 
 		return errors.Errorf("unsupported continent(s) %s", notfound)
 	}
-	
+
 	return nil
 }
 

--- a/internal/app/telescopes/api/validate.go
+++ b/internal/app/telescopes/api/validate.go
@@ -21,7 +21,6 @@ import (
 	"github.com/banzaicloud/telescopes/pkg/recommender"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/goph/emperror"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/pkg/errors"
 	"gopkg.in/go-playground/validator.v8"
 )
@@ -94,15 +93,40 @@ type pathParamValidator struct {
 }
 
 func (ppV *pathParamValidator) ValidateContinents(continents []string) error {
+
 	ciContinents, err := ppV.ciCli.GetContinents()
 	if err != nil {
+
 		return err
 	}
 
-	if ok, diff := helper.SliceStringIsSubset(ciContinents, continents); !ok {
-		return errors.Errorf("unsupported continent(s) %s", diff)
+	var (
+		found    bool
+		notfound = make([]string, 0)
+	)
+
+	for _, continent := range continents {
+
+		found = false
+		for _, ciContinent := range ciContinents {
+
+			if continent == ciContinent {
+
+				found = true
+				continue
+			}
+		}
+
+		if !found {
+			notfound = append(notfound, continent)
+		}
 	}
 
+	if len(notfound) > 0 {
+
+		return errors.Errorf("unsupported continent(s) %s", notfound)
+	}
+	
 	return nil
 }
 

--- a/internal/app/telescopes/api/validate.go
+++ b/internal/app/telescopes/api/validate.go
@@ -39,7 +39,7 @@ const (
 )
 
 // ConfigureValidator configures the Gin validator with custom validator functions
-func ConfigureValidator(ciCli *recommender.CloudInfoClient) error {
+func ConfigureValidator() error {
 	v := binding.Validator.Engine().(*validator.Validate)
 
 	if err := v.RegisterValidation("networkPerf", networkPerfValidator()); err != nil {
@@ -89,7 +89,7 @@ type CloudInfoValidator interface {
 }
 
 type pathParamValidator struct {
-	ciCli *recommender.CloudInfoClient
+	ciCli recommender.CloudInfoSource
 }
 
 func (ppV *pathParamValidator) ValidateContinents(continents []string) error {
@@ -184,6 +184,6 @@ func (ppV *pathParamValidator) validateRegion(prv, svc, region string) error {
 	return nil
 }
 
-func NewCloudInfoValidator(ciCli *recommender.CloudInfoClient) CloudInfoValidator {
+func NewCloudInfoValidator(ciCli recommender.CloudInfoSource) CloudInfoValidator {
 	return &pathParamValidator{ciCli}
 }

--- a/pkg/recommender/engine.go
+++ b/pkg/recommender/engine.go
@@ -278,7 +278,7 @@ func (e *Engine) RecommendMultiCluster(req MultiClusterRecommendationReq) (map[s
 
 	for _, provider := range req.Providers {
 		for _, service := range provider.Services {
-			regions, err := e.getRegions(provider.Provider, service, req)
+			regions, err := e.getRegions(provider.Provider, service, req.Continents)
 			if err != nil {
 				return nil, err
 			}
@@ -348,15 +348,15 @@ func (e *Engine) recommendCluster(provider, service, region string, req MultiClu
 	return response, nil
 }
 
-func (e *Engine) getRegions(provider, service string, req MultiClusterRecommendationReq) ([]string, error) {
+func (e *Engine) getRegions(provider, service string, continents []string) ([]string, error) {
 	var regions []string
-	continents, err := e.ciSource.GetContinentsData(provider, service)
+	continentsData, err := e.ciSource.GetContinentsData(provider, service)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, validContinent := range req.Continents {
-		for _, continent := range continents {
+	for _, validContinent := range continents {
+		for _, continent := range continentsData {
 			if validContinent == continent.Name {
 				for _, region := range continent.Regions {
 					regions = append(regions, region.Id)

--- a/pkg/recommender/engine_test.go
+++ b/pkg/recommender/engine_test.go
@@ -27,6 +27,22 @@ type dummyProducts struct {
 	TcId string
 }
 
+func (p *dummyProducts) GetContinents() ([]string, error) {
+	panic("implement me")
+}
+
+func (p *dummyProducts) GetRegion(provider string, service string, region string) (string, error) {
+	panic("implement me")
+}
+
+func (p *dummyProducts) GetProvider(provider string) (string, error) {
+	panic("implement me")
+}
+
+func (p *dummyProducts) GetService(provider string, service string) (string, error) {
+	panic("implement me")
+}
+
 func (p *dummyProducts) GetContinentsData(provider, service string) ([]cloudinfo.Continent, error) {
 	panic("implement me")
 }

--- a/pkg/recommender/product.go
+++ b/pkg/recommender/product.go
@@ -46,8 +46,8 @@ type CloudInfoClient struct {
 }
 
 const (
-	cloudInfoErrTag    = "cloud-info"
-	cloudInfoCliErrTag = "cloud-info-client"
+	cloudInfoService         = "cloud-info"
+	cloudInfoClientComponent = "cloud-info-client"
 )
 
 // NewCloudInfoClient creates a new product info client wrapper instance
@@ -59,7 +59,7 @@ func NewCloudInfoClient(ciUrl string, logger logur.Logger) *CloudInfoClient {
 	})
 	return &CloudInfoClient{
 		APIClient: apiCli,
-		logger:    logur.WithFields(logger, map[string]interface{}{"cli": "ciClient"}),
+		logger:    logur.WithFields(logger, map[string]interface{}{"cli": cloudInfoClientComponent}),
 	}
 }
 
@@ -223,10 +223,10 @@ func discriminateErrCtx(err error) error {
 
 	if _, ok := err.(*runtime.APIError); ok {
 		// the service can be reached
-		return emperror.With(err, cloudInfoErrTag)
+		return emperror.With(err, cloudInfoService)
 	}
 	// handle other cloud info errors here
 
 	// probably connectivity error (should it be analized further?!)
-	return emperror.With(err, cloudInfoCliErrTag)
+	return emperror.With(err, cloudInfoClientComponent)
 }

--- a/pkg/recommender/types.go
+++ b/pkg/recommender/types.go
@@ -96,7 +96,7 @@ type ClusterRecommendationReq struct {
 // swagger:model recommendMultiCluster
 type MultiClusterRecommendationReq struct {
 	Providers  []Provider `json:"providers" binding:"required"`
-	Continents []string   `json:"continents" binding:"required,dive,continents"`
+	Continents []string   `json:"continents"`
 	// Embedded struct
 	ClusterRecommendationReq
 	// Excludes is a blacklist - a slice with vm types to be excluded from the recommendation


### PR DESCRIPTION
* continent validation moved to the handler instead of being done at binding (that approach resulted in superfluous calls to the cloudinfo service)
* added logger to the cloud info client wrapper to better track the reqest flow
* cloudinfo client hidden behind an interface / dependency on the generated code minimalised

fixes #212 